### PR TITLE
 itemsの作成/保存までAPIを接続

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -15,6 +15,7 @@ module.exports = function (api) {
             store: './src/store',
             hooks: './src/hooks',
             queries: './src/queries',
+            __mockData__: './src/__mockData__',
           },
         },
       ],

--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
     "build-storybook": "build-storybook",
     "lint": "eslint --ext .js,.ts,.tsx 'src/**'",
     "download:schema.graphqls": "curl -L -O https://raw.githubusercontent.com/wheatandcat/memoir-backend/main/graph/schema.graphqls",
-    "codegen": "graphql-codegen",
+    "codegen": "yarn download:schema.graphqls & graphql-codegen",
     "codegen:lint:fix": "eslint --fix ./src/queries/api/index.ts"
   },
   "dependencies": {
-    "@apollo/client": "^3.3.11",
+    "@apollo/client": "3.2.5",
     "@react-native-async-storage/async-storage": "^1.14.1",
     "@react-native-community/masked-view": "0.1.10",
     "@react-navigation/native": "^5.9.2",

--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -1,0 +1,2 @@
+declare type QueryData<T1, T2> = NonNullable<NonNullable<T1['data']>[T2]>;
+declare type ArrayType<T> = T extends Array<infer V> ? V : never;

--- a/src/__mockData__/item.tsx
+++ b/src/__mockData__/item.tsx
@@ -1,0 +1,19 @@
+import { ItemQuery } from 'queries/api/index';
+type Item = ItemQuery['item'];
+
+export const item = (option?: Partial<Item>): Item => ({
+  id: '1',
+  title: '買い物',
+  categoryID: 9,
+  date: '2021-01-01T00:00:00+09:00',
+  like: false,
+  dislike: false,
+  createdAt: '2021-01-01T00:00:00+09:00',
+  updatedAt: '2021-01-01T00:00:00+09:00',
+  ...option,
+});
+
+export const items = (): Item[] => [
+  item(),
+  item({ id: '2', title: '本を読む', categoryID: 2 }),
+];

--- a/src/components/organisms/AddItemModal/AddItemModal.tsx
+++ b/src/components/organisms/AddItemModal/AddItemModal.tsx
@@ -7,15 +7,17 @@ import Categories from 'components/organisms/Categories';
 import dayjs from 'dayjs';
 import advancedFormat from 'dayjs/plugin/advancedFormat';
 import 'dayjs/locale/ja';
+import { NewItem } from 'queries/api/index';
 
 dayjs.locale('ja');
 dayjs.extend(advancedFormat);
 
 type Props = {
   isVisible: boolean;
+  loading: boolean;
   date: string;
   onClose: () => void;
-  onAdd: (state: State) => void;
+  onAdd: (newItem: NewItem) => void;
 };
 
 type State = {
@@ -39,6 +41,18 @@ const AddItemModal: React.FC<Props> = (props) => {
     setState((s) => ({ ...s, title }));
   }, []);
 
+  const onAdd = useCallback(() => {
+    const item: NewItem = {
+      title: state.title,
+      categoryID: state.categoryID || 0,
+      date: dayjs(props.date).format('YYYY-MM-DDT00:00:00+09:00'),
+      like: false,
+      dislike: false,
+    };
+
+    props.onAdd(item);
+  }, [props, state]);
+
   const valid = useCallback(() => {
     if (state.title === '') {
       return false;
@@ -57,11 +71,16 @@ const AddItemModal: React.FC<Props> = (props) => {
       title={dayjs(props.date).format('YYYY.MM.DD / ddd')}
       onClose={props.onClose}
       buttonTitle="入力"
-      disabledButton={!valid()}
-      onPress={() => props.onAdd(state)}
+      disabledButton={!valid() && !props.loading}
+      onPress={onAdd}
+      loading={props.loading}
     >
       <View style={styles.root} p={1} px={3}>
-        <TextInput placeholder="終了したタスク" onChangeText={onChangeTitle} />
+        <TextInput
+          placeholder="終了したタスク"
+          onChangeText={onChangeTitle}
+          autoFocus
+        />
         <View py={2}>
           <Categories categoryID={state.categoryID} onPress={onCategory} />
         </View>

--- a/src/components/organisms/AddItemModal/AddItemModal.tsx
+++ b/src/components/organisms/AddItemModal/AddItemModal.tsx
@@ -80,6 +80,7 @@ const AddItemModal: React.FC<Props> = (props) => {
           placeholder="終了したタスク"
           onChangeText={onChangeTitle}
           autoFocus
+          returnKeyType="done"
         />
         <View py={2}>
           <Categories categoryID={state.categoryID} onPress={onCategory} />

--- a/src/components/organisms/AddItemModal/stories.tsx
+++ b/src/components/organisms/AddItemModal/stories.tsx
@@ -8,6 +8,7 @@ storiesOf('organisms', module).add('AddItemModal', () => (
   <View>
     <AddItemModal
       isVisible
+      loading={false}
       date="2020-01-01"
       onClose={mockFn('onClose')}
       onAdd={mockFn('onCategory')}

--- a/src/components/organisms/Card/Card.tsx
+++ b/src/components/organisms/Card/Card.tsx
@@ -10,6 +10,9 @@ import Text from 'components/atoms/Text';
 import Category from 'components/atoms/Category';
 import theme from 'config/theme';
 import Image from 'components/atoms/Image';
+import { Item } from 'queries/api/index';
+import master from 'lib/master';
+import setting from 'components/atoms/Category/setting';
 
 type User = {
   id: string;
@@ -17,7 +20,8 @@ type User = {
 };
 
 type Props = {
-  title: string;
+  title: Item['title'];
+  categoryID: Item['categoryID'];
   user?: User;
   onPress: () => void;
 };
@@ -38,11 +42,27 @@ const Card: React.FC<Props> = (props) => {
     rootStyle.height = 95;
   }
 
+  const category = setting().icon.find((v) => v.id === props.categoryID)
+    ?.category;
+
+  const categoryStyle: ViewStyle[] = [styles.root, rootStyle];
+  switch (category) {
+    case master.CATEGORY_1:
+      categoryStyle.push(styles.category1);
+      break;
+    case master.CATEGORY_2:
+      categoryStyle.push(styles.category2);
+      break;
+    case master.CATEGORY_3:
+      categoryStyle.push(styles.category3);
+      break;
+  }
+
   return (
     <TouchableOpacity onPress={props.onPress}>
-      <View style={[styles.root, rootStyle]}>
+      <View style={categoryStyle}>
         <View mx={2}>
-          <Category categoryID={2} />
+          <Category categoryID={props.categoryID} />
         </View>
         <View>
           <View style={[styles.title, titleStyle]}>
@@ -76,7 +96,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     borderLeftWidth: 5,
-    borderColor: theme().category.color.category1,
   },
   title: {
     paddingLeft: theme().space(0),
@@ -85,5 +104,14 @@ const styles = StyleSheet.create({
     paddingVertical: theme().space(2),
     flexDirection: 'row',
     alignItems: 'center',
+  },
+  category1: {
+    borderLeftColor: theme().category.color.category1,
+  },
+  category2: {
+    borderLeftColor: theme().category.color.category4,
+  },
+  category3: {
+    borderLeftColor: theme().category.color.category2,
   },
 });

--- a/src/components/organisms/Card/stories.tsx
+++ b/src/components/organisms/Card/stories.tsx
@@ -4,5 +4,5 @@ import { mockFn } from 'storyBookUtils/index';
 import Card from './Card';
 
 storiesOf('organisms/Card', module).add('Card', () => (
-  <Card title="本を読んだ" onPress={mockFn('onPress')} />
+  <Card title="本を読んだ" categoryID={1} onPress={mockFn('onPress')} />
 ));

--- a/src/components/organisms/CardDetail/CardDetail.tsx
+++ b/src/components/organisms/CardDetail/CardDetail.tsx
@@ -16,6 +16,7 @@ dayjs.extend(advancedFormat);
 
 type Props = {
   title: string;
+  date: string;
   categoryID: number;
 };
 
@@ -45,7 +46,7 @@ const CardDetail: React.FC<Props> = (props) => {
     <View style={categoryStyle}>
       <View style={styles.header}>
         <View>
-          <Text>{dayjs().format('YYYY.MM.DD / ddd')}</Text>
+          <Text>{dayjs(props.date).format('YYYY.MM.DD / ddd')}</Text>
         </View>
         <View>
           <IconButton name="more-horiz" size="base" onPress={() => null} />

--- a/src/components/organisms/CardDetail/CardDetail.tsx
+++ b/src/components/organisms/CardDetail/CardDetail.tsx
@@ -1,5 +1,5 @@
 import React, { memo } from 'react';
-import { StyleSheet, useWindowDimensions } from 'react-native';
+import { StyleSheet, useWindowDimensions, ViewStyle } from 'react-native';
 import View from 'components/atoms/View';
 import Text from 'components/atoms/Text';
 import Category from 'components/atoms/Category';
@@ -8,12 +8,15 @@ import theme from 'config/theme';
 import dayjs from 'dayjs';
 import advancedFormat from 'dayjs/plugin/advancedFormat';
 import 'dayjs/locale/ja';
+import master from 'lib/master';
+import setting from 'components/atoms/Category/setting';
 
 dayjs.locale('ja');
 dayjs.extend(advancedFormat);
 
 type Props = {
   title: string;
+  categoryID: number;
 };
 
 const CardDetail: React.FC<Props> = (props) => {
@@ -23,8 +26,23 @@ const CardDetail: React.FC<Props> = (props) => {
     width: windowWidth - 60,
   };
 
+  const category = setting().icon.find((v) => v.id === props.categoryID)
+    ?.category;
+  const categoryStyle: ViewStyle[] = [styles.root];
+  switch (category) {
+    case master.CATEGORY_1:
+      categoryStyle.push(styles.category1);
+      break;
+    case master.CATEGORY_2:
+      categoryStyle.push(styles.category2);
+      break;
+    case master.CATEGORY_3:
+      categoryStyle.push(styles.category3);
+      break;
+  }
+
   return (
-    <View style={styles.root}>
+    <View style={categoryStyle}>
       <View style={styles.header}>
         <View>
           <Text>{dayjs().format('YYYY.MM.DD / ddd')}</Text>
@@ -34,7 +52,7 @@ const CardDetail: React.FC<Props> = (props) => {
         </View>
       </View>
       <View style={styles.icon}>
-        <Category categoryID={2} />
+        <Category categoryID={props.categoryID} />
       </View>
       <View style={[styles.title, titleStyle]}>
         <Text lineHeight={25}>{props.title}</Text>
@@ -54,7 +72,6 @@ const styles = StyleSheet.create({
   root: {
     backgroundColor: theme().color.background.light,
     borderLeftWidth: 5,
-    borderColor: theme().category.color.category1,
     paddingHorizontal: theme().space(3),
     paddingVertical: theme().space(2),
   },
@@ -76,5 +93,14 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
+  },
+  category1: {
+    borderLeftColor: theme().category.color.category1,
+  },
+  category2: {
+    borderLeftColor: theme().category.color.category4,
+  },
+  category3: {
+    borderLeftColor: theme().category.color.category2,
   },
 });

--- a/src/components/organisms/CardDetail/stories.tsx
+++ b/src/components/organisms/CardDetail/stories.tsx
@@ -8,7 +8,10 @@ import CardDetail from './CardDetail';
 
 storiesOf('organisms/CardDetail', module).add('CardDetail', () => (
   <View p={3} style={styles.root}>
-    <CardDetail title="とても長いタイトルの本を読んだことがあって次もまた長いタイトルの本を読む" />
+    <CardDetail
+      categoryID={1}
+      title="とても長いタイトルの本を読んだことがあって次もまた長いタイトルの本を読む"
+    />
   </View>
 ));
 

--- a/src/components/organisms/CardDetail/stories.tsx
+++ b/src/components/organisms/CardDetail/stories.tsx
@@ -9,6 +9,7 @@ import CardDetail from './CardDetail';
 storiesOf('organisms/CardDetail', module).add('CardDetail', () => (
   <View p={3} style={styles.root}>
     <CardDetail
+      date="2021-02-21"
       categoryID={1}
       title="とても長いタイトルの本を読んだことがあって次もまた長いタイトルの本を読む"
     />

--- a/src/components/organisms/Cards/Cards.tsx
+++ b/src/components/organisms/Cards/Cards.tsx
@@ -1,32 +1,39 @@
 import React, { memo } from 'react';
-import { StyleSheet } from 'react-native';
+import { ActivityIndicator, StyleSheet } from 'react-native';
 import View from 'components/atoms/View';
 import Card from 'components/organisms/Card';
 import AddButton from 'components/molecules/Home/AddButton';
+import { ItemQuery } from 'queries/api/index';
+import theme from 'config/theme';
 
-type Props = {
+type Item = ItemQuery['item'];
+
+export type Props = {
+  loading: boolean;
+  items: Item[];
   onItem: () => void;
   onAddItem: () => void;
 };
-
-const items = [
-  {
-    title: '本読んだ',
-  },
-  {
-    title:
-      '「とても長いタイトルの本」を読んだんだけど、もっと長いタイトルの本です',
-  },
-];
 
 const Cards: React.FC<Props> = (props) => {
   return (
     <View style={styles.root}>
       <AddButton onPress={props.onAddItem} />
+
+      {props.loading && (
+        <View style={styles.loading} mb={3} mx={3}>
+          <ActivityIndicator size="large" />
+        </View>
+      )}
+
       <View>
-        {items.map((v) => (
-          <View key={v.title} mb={3} mx={3}>
-            <Card title={v.title} onPress={props.onItem} />
+        {(props.items || []).map((v) => (
+          <View key={v?.id} mb={3} mx={3}>
+            <Card
+              title={v?.title || ''}
+              categoryID={v?.categoryID || 0}
+              onPress={props.onItem}
+            />
           </View>
         ))}
       </View>
@@ -38,4 +45,10 @@ export default memo(Cards);
 
 const styles = StyleSheet.create({
   root: {},
+  loading: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    height: 75,
+    backgroundColor: theme().color.background.light,
+  },
 });

--- a/src/components/organisms/Cards/Cards.tsx
+++ b/src/components/organisms/Cards/Cards.tsx
@@ -11,7 +11,7 @@ type Item = ItemQuery['item'];
 export type Props = {
   loading: boolean;
   items: Item[];
-  onItem: () => void;
+  onItem: (itemID: string) => void;
   onAddItem: () => void;
 };
 
@@ -32,7 +32,7 @@ const Cards: React.FC<Props> = (props) => {
             <Card
               title={v?.title || ''}
               categoryID={v?.categoryID || 0}
-              onPress={props.onItem}
+              onPress={() => props.onItem(v?.id || '')}
             />
           </View>
         ))}

--- a/src/components/organisms/Cards/stories.tsx
+++ b/src/components/organisms/Cards/stories.tsx
@@ -1,8 +1,16 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react-native';
 import { mockFn } from 'storyBookUtils/index';
-import Cards from './Cards';
+import { items } from '__mockData__/item';
+import Cards, { Props } from './Cards';
 
-storiesOf('organisms/Cards', module).add('Cards', () => (
-  <Cards onItem={mockFn('onItem')} onAddItem={mockFn('onAddItem')} />
-));
+const props = (loading: boolean): Props => ({
+  items: items(),
+  onItem: mockFn('onItem'),
+  onAddItem: mockFn('onAddItem'),
+  loading,
+});
+
+storiesOf('organisms/Cards', module)
+  .add('デフォルト', () => <Cards {...props(false)} />)
+  .add('ローディング', () => <Cards {...props(true)} />);

--- a/src/components/organisms/Error/Error.tsx
+++ b/src/components/organisms/Error/Error.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import View from 'components/atoms/View';
+import Text from 'components/atoms/Text';
+import { ApolloError } from '@apollo/client';
+import theme from 'config/theme';
+
+type Props = {
+  error?: ApolloError;
+};
+
+const Error: React.FC<Props> = () => {
+  return (
+    <View>
+      <Text style={styles.text}>エラーが発生しました</Text>
+    </View>
+  );
+};
+
+export default Error;
+
+const styles = StyleSheet.create({
+  text: {
+    textAlign: 'center',
+    height: '100%',
+    width: '100%',
+    backgroundColor: theme().color.background.light,
+  },
+});

--- a/src/components/organisms/Loading/Loading.tsx
+++ b/src/components/organisms/Loading/Loading.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { ActivityIndicator, Dimensions, StyleSheet } from 'react-native';
+import View from 'components/atoms/View';
+import theme from 'config/theme';
+
+const deviceHeight = Dimensions.get('screen').height;
+const deviceWidth = Dimensions.get('window').width;
+
+type Props = {
+  loading: boolean;
+  row?: boolean;
+};
+
+const Loading: React.FC<Props> = (props) => {
+  if (!props.loading) return <>{props.children}</>;
+
+  return props.row ? (
+    <ActivityIndicator size="large" />
+  ) : (
+    <View style={[styles.container, styles.background]} {...props}>
+      <View style={styles.inner}>
+        <ActivityIndicator size="large" />
+      </View>
+    </View>
+  );
+};
+
+export default Loading;
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: deviceWidth,
+    height: deviceHeight,
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    opacity: 0.8,
+  },
+  inner: {
+    flex: 1,
+    position: 'absolute',
+    top: '35%',
+  },
+  background: {
+    backgroundColor: theme().color.background.light,
+    height: '100%',
+    width: '100%',
+  },
+});

--- a/src/components/organisms/Memoir/DateCards.tsx
+++ b/src/components/organisms/Memoir/DateCards.tsx
@@ -92,6 +92,7 @@ const renderItem = (
     <View mb={3} mx={3} key={`${index}-contents`}>
       <Card
         title={item?.contents?.title || ''}
+        categoryID={1}
         user={item?.contents?.user}
         onPress={props.onItem}
       />

--- a/src/components/organisms/Modal/Modal.tsx
+++ b/src/components/organisms/Modal/Modal.tsx
@@ -9,6 +9,7 @@ import IconButton from 'components/molecules/IconButton';
 
 type Props = {
   isVisible: boolean;
+  loading?: boolean;
   title: string;
   buttonTitle?: string;
   disabledButton?: boolean;
@@ -45,6 +46,7 @@ const Modal: React.FC<Props> = (props) => {
               size="lg"
               onPress={() => props.onPress?.()}
               disabled={props.disabledButton}
+              loading={props.loading}
             />
           </View>
         )}

--- a/src/components/organisms/Modal/stories.tsx
+++ b/src/components/organisms/Modal/stories.tsx
@@ -7,7 +7,12 @@ import Modal from './';
 
 storiesOf('organisms', module).add('Modal', () => (
   <View>
-    <Modal title="タイトル" isVisible={true} onClose={mockFn('onClose')}>
+    <Modal
+      title="タイトル"
+      isVisible={true}
+      onClose={mockFn('onClose')}
+      loading={false}
+    >
       <View pt={5}>
         <Text textAlign="center" variants="large">
           props.children

--- a/src/components/pages/Home/Connected.tsx
+++ b/src/components/pages/Home/Connected.tsx
@@ -104,7 +104,7 @@ const Connected: React.FC<Props> = (props) => {
       loading={loading}
       error={error}
       addItemLoading={false}
-      date={dayjs().format('YYYY-MM-DD')}
+      date={dayjs(state.date).format('YYYY-MM-DD')}
       openAddItemModal={state.openAddItemModal}
       openSettingModal={props.openSettingModal}
       onAddItem={onAddItem}

--- a/src/components/pages/Home/Connected.tsx
+++ b/src/components/pages/Home/Connected.tsx
@@ -32,7 +32,7 @@ export type ConnectedType = {
   onChangeDate: (date: string) => void;
   onCloseAddItem: () => void;
   onCloseSettingModal: () => void;
-  onItem: () => void;
+  onItem: (itemID: string) => void;
   onMemoir: () => void;
   onOpenAddItem: () => void;
 };
@@ -60,8 +60,6 @@ const Connected: React.FC<Props> = (props) => {
 
   const [createItemMutation] = useCreateItemMutation({
     async onCompleted() {
-      console.log('onCompleted');
-
       await refetch?.();
 
       onCloseAddItem();
@@ -79,11 +77,22 @@ const Connected: React.FC<Props> = (props) => {
     [createItemMutation]
   );
 
-  const onChangeDate = useCallback(() => {}, []);
+  const onChangeDate = useCallback((date: string) => {
+    setState((s) => ({
+      ...s,
+      date: dayjs(date).format('YYYY-MM-DDT00:00:00+09:00'),
+    }));
+  }, []);
 
-  const onItem = useCallback(() => {
-    props.navigation.navigate('ItemDetail');
-  }, [props.navigation]);
+  const onItem = useCallback(
+    (itemID: string) => {
+      props.navigation.navigate('ItemDetail', {
+        id: itemID,
+        date: state.date,
+      });
+    },
+    [props.navigation, state.date]
+  );
 
   const onMemoir = useCallback(() => {
     props.navigation.navigate('Memoir');

--- a/src/components/pages/Home/Plain.tsx
+++ b/src/components/pages/Home/Plain.tsx
@@ -1,0 +1,22 @@
+import React, { memo } from 'react';
+import { ItemsByDateQueryHookResult as QueryHookResult } from 'queries/api/index';
+import ErrorPage from 'components/organisms/Error/Error';
+import Loading from 'components/organisms/Loading/Loading';
+import TemplateHome from 'components/templates/Home/Page';
+import { ConnectedType } from './Connected';
+
+export type QueryProps = Pick<QueryHookResult, 'data' | 'loading' | 'error'>;
+
+type Props = QueryProps & ConnectedType;
+
+const Plain: React.FC<Props> = (props) => {
+  if (props.error) return <ErrorPage error={props.error} />;
+  if (props.loading && (props.data?.itemsByDate?.length || 0) === 0)
+    return <Loading loading />;
+
+  const items = props.data?.itemsByDate || [];
+
+  return <TemplateHome {...props} items={items} />;
+};
+
+export default memo<Props>(Plain);

--- a/src/components/pages/ItemDetail/Connected.tsx
+++ b/src/components/pages/ItemDetail/Connected.tsx
@@ -1,0 +1,41 @@
+import React, { memo, useCallback } from 'react';
+import dayjs from 'dayjs';
+import advancedFormat from 'dayjs/plugin/advancedFormat';
+import 'dayjs/locale/ja';
+import { useItemQuery } from 'queries/api/index';
+import Plain from './Plain';
+
+dayjs.locale('ja');
+dayjs.extend(advancedFormat);
+
+type Props = {
+  itemID: string;
+  date: string;
+};
+
+export type ConnectedType = {
+  date: string;
+  onChangeDate: (date: string) => void;
+};
+
+const Connected: React.FC<Props> = (props) => {
+  const { loading, data, error } = useItemQuery({
+    variables: {
+      id: props.itemID,
+    },
+  });
+
+  const onChangeDate = useCallback(() => {}, []);
+
+  return (
+    <Plain
+      data={data}
+      loading={loading}
+      error={error}
+      date={dayjs(props.date).format('YYYY-MM-DD')}
+      onChangeDate={onChangeDate}
+    />
+  );
+};
+
+export default memo(Connected);

--- a/src/components/pages/ItemDetail/Plain.tsx
+++ b/src/components/pages/ItemDetail/Plain.tsx
@@ -1,7 +1,7 @@
 import React, { memo } from 'react';
-import { ItemsByDateQueryHookResult as QueryHookResult } from 'queries/api/index';
+import { ItemQueryHookResult as QueryHookResult } from 'queries/api/index';
 import ErrorPage from 'components/organisms/Error/Error';
-import TemplateHome from 'components/templates/Home/Page';
+import TemplateItemDetail from 'components/templates/ItemDetail/Page';
 import { ConnectedType } from './Connected';
 
 export type QueryProps = Pick<QueryHookResult, 'data' | 'loading' | 'error'>;
@@ -11,9 +11,17 @@ type Props = QueryProps & ConnectedType;
 const Plain: React.FC<Props> = (props) => {
   if (props.error) return <ErrorPage error={props.error} />;
 
-  const items = props.data?.itemsByDate || [];
+  const item = props.data?.item;
 
-  return <TemplateHome {...props} items={items} />;
+  return (
+    <TemplateItemDetail
+      loading
+      date={props.date}
+      onChangeDate={props.onChangeDate}
+      title={item?.title || ''}
+      categoryID={item?.categoryID || 0}
+    />
+  );
 };
 
 export default memo<Props>(Plain);

--- a/src/components/pages/ItemDetail/index.tsx
+++ b/src/components/pages/ItemDetail/index.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useCallback } from 'react';
-import TemplateItemDetail from 'components/templates/ItemDetail/Page.tsx';
+import TemplateItemDetail from 'components/templates/ItemDetail/Page';
 import { RootStackParamList } from 'lib/navigation';
 import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';

--- a/src/components/pages/ItemDetail/index.tsx
+++ b/src/components/pages/ItemDetail/index.tsx
@@ -1,5 +1,4 @@
-import React, { memo, useCallback } from 'react';
-import TemplateItemDetail from 'components/templates/ItemDetail/Page';
+import React, { memo } from 'react';
 import { RootStackParamList } from 'lib/navigation';
 import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
@@ -7,6 +6,7 @@ import theme from 'config/theme';
 import dayjs from 'dayjs';
 import advancedFormat from 'dayjs/plugin/advancedFormat';
 import 'dayjs/locale/ja';
+import Connected from './Connected';
 
 dayjs.locale('ja');
 dayjs.extend(advancedFormat);
@@ -22,14 +22,9 @@ export type Props = {
   route: ScreenRouteProp;
 };
 
-const ItemDetail: React.FC<Props> = () => {
-  const onChangeDate = useCallback(() => {}, []);
-
+const ItemDetail: React.FC<Props> = (props) => {
   return (
-    <TemplateItemDetail
-      date={dayjs().format('YYYY-MM-DD')}
-      onChangeDate={onChangeDate}
-    />
+    <Connected date={props.route.params.date} itemID={props.route.params.id} />
   );
 };
 

--- a/src/components/templates/Home/Page.tsx
+++ b/src/components/templates/Home/Page.tsx
@@ -10,6 +10,9 @@ import SettingModal from 'components/organisms/SettingModal';
 import AddItemModal from 'components/organisms/AddItemModal';
 import InputDateWrap from 'components/organisms/InputDateWrap/InputDateWrap';
 import { ConnectedType } from 'components/pages/Home/Connected';
+import { ItemQuery } from 'queries/api/index';
+
+type Item = ItemQuery['item'];
 
 dayjs.locale('ja');
 dayjs.extend(advancedFormat);
@@ -17,6 +20,7 @@ dayjs.extend(advancedFormat);
 type Props = {
   addItemLoading: boolean;
   date: string;
+  items: Item[];
 } & ConnectedType;
 
 const Page: React.FC<Props> = (props) => {
@@ -36,7 +40,12 @@ const Page: React.FC<Props> = (props) => {
         />
         <ScrollView>
           <View style={styles.inner}>
-            <Cards onItem={props.onItem} onAddItem={props.onOpenAddItem} />
+            <Cards
+              loading={props.addItemLoading}
+              items={props.items}
+              onItem={props.onItem}
+              onAddItem={props.onOpenAddItem}
+            />
           </View>
         </ScrollView>
         <MemoirButton onPress={props.onMemoir} />

--- a/src/components/templates/Home/Page.tsx
+++ b/src/components/templates/Home/Page.tsx
@@ -34,7 +34,7 @@ const Page: React.FC<Props> = (props) => {
         <AddItemModal
           isVisible={props.openAddItemModal}
           loading={props.addItemLoading}
-          date={dayjs().format('YYYY-MM-DD')}
+          date={dayjs(props.date).format('YYYY-MM-DD')}
           onAdd={props.onAddItem}
           onClose={props.onCloseAddItem}
         />

--- a/src/components/templates/Home/Page.tsx
+++ b/src/components/templates/Home/Page.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useState } from 'react';
+import React, { memo } from 'react';
 import { StyleSheet, ScrollView } from 'react-native';
 import View from 'components/atoms/View';
 import dayjs from 'dayjs';
@@ -9,31 +9,17 @@ import Cards from 'components/organisms/Cards/Cards';
 import SettingModal from 'components/organisms/SettingModal';
 import AddItemModal from 'components/organisms/AddItemModal';
 import InputDateWrap from 'components/organisms/InputDateWrap/InputDateWrap';
+import { ConnectedType } from 'components/pages/Home/Connected';
 
 dayjs.locale('ja');
 dayjs.extend(advancedFormat);
 
 type Props = {
+  addItemLoading: boolean;
   date: string;
-  openSettingModal: boolean;
-  onAddItem: () => void;
-  onItem: () => void;
-  onMemoir: () => void;
-  onCloseSettingModal: () => void;
-  onChangeDate: (date: string) => void;
-};
-
-type State = {
-  openAddItemModal: boolean;
-};
-
-const initialState = (): State => ({
-  openAddItemModal: false,
-});
+} & ConnectedType;
 
 const Page: React.FC<Props> = (props) => {
-  const [state, setState] = useState<State>(initialState());
-
   return (
     <InputDateWrap date={props.date} onChangeDate={props.onChangeDate}>
       <>
@@ -42,19 +28,15 @@ const Page: React.FC<Props> = (props) => {
           onClose={props.onCloseSettingModal}
         />
         <AddItemModal
-          isVisible={state.openAddItemModal}
+          isVisible={props.openAddItemModal}
+          loading={props.addItemLoading}
           date={dayjs().format('YYYY-MM-DD')}
           onAdd={props.onAddItem}
-          onClose={() => setState((s) => ({ ...s, openAddItemModal: false }))}
+          onClose={props.onCloseAddItem}
         />
         <ScrollView>
           <View style={styles.inner}>
-            <Cards
-              onItem={props.onItem}
-              onAddItem={() =>
-                setState((s) => ({ ...s, openAddItemModal: true }))
-              }
-            />
+            <Cards onItem={props.onItem} onAddItem={props.onOpenAddItem} />
           </View>
         </ScrollView>
         <MemoirButton onPress={props.onMemoir} />

--- a/src/components/templates/Home/stories.tsx
+++ b/src/components/templates/Home/stories.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react-native';
 import { mockFn } from 'storyBookUtils/index';
+import { items } from '__mockData__/item';
 import Page from './Page';
 
 storiesOf('templates/Home', module).add('Page', () => (
   <Page
+    items={items()}
     date="2021-02-21"
     addItemLoading={false}
     openSettingModal={false}

--- a/src/components/templates/Home/stories.tsx
+++ b/src/components/templates/Home/stories.tsx
@@ -6,11 +6,15 @@ import Page from './Page';
 storiesOf('templates/Home', module).add('Page', () => (
   <Page
     date="2021-02-21"
+    addItemLoading={false}
     openSettingModal={false}
+    openAddItemModal={false}
     onItem={mockFn('onItem')}
     onMemoir={mockFn('onMemoir')}
     onCloseSettingModal={mockFn('onCloseSettingModal')}
     onChangeDate={mockFn('onChangeDate')}
     onAddItem={mockFn('onAddItem')}
+    onOpenAddItem={mockFn('onOpenAddItem')}
+    onCloseAddItem={mockFn('onCloseAddItem')}
   />
 ));

--- a/src/components/templates/ItemDetail/Page.tsx
+++ b/src/components/templates/ItemDetail/Page.tsx
@@ -24,7 +24,11 @@ const Page: React.FC<Props> = (props) => {
       <ScrollView>
         <View style={styles.inner}>
           {props.loading && (
-            <CardDetail title={props.title} categoryID={props.categoryID} />
+            <CardDetail
+              date={props.date}
+              title={props.title}
+              categoryID={props.categoryID}
+            />
           )}
         </View>
       </ScrollView>

--- a/src/components/templates/ItemDetail/Page.tsx
+++ b/src/components/templates/ItemDetail/Page.tsx
@@ -4,8 +4,12 @@ import View from 'components/atoms/View';
 import CardDetail from 'components/organisms/CardDetail/CardDetail';
 import InputDateWrap from 'components/organisms/InputDateWrap/InputDateWrap';
 import theme from 'config/theme';
+import { ItemQuery } from 'queries/api/index';
 
-type Props = {
+type Item = NonNullable<ItemQuery['item']>;
+
+type Props = Pick<Item, 'categoryID' | 'title'> & {
+  loading: boolean;
   date: string;
   onChangeDate: (date: string) => void;
 };
@@ -19,7 +23,9 @@ const Page: React.FC<Props> = (props) => {
     >
       <ScrollView>
         <View style={styles.inner}>
-          <CardDetail title="本を読んだ" />
+          {props.loading && (
+            <CardDetail title={props.title} categoryID={props.categoryID} />
+          )}
         </View>
       </ScrollView>
     </InputDateWrap>

--- a/src/components/templates/ItemDetail/stories.tsx
+++ b/src/components/templates/ItemDetail/stories.tsx
@@ -4,5 +4,11 @@ import { mockFn } from 'storyBookUtils/index';
 import Page from './Page';
 
 storiesOf('templates/ItemDetail', module).add('Page', () => (
-  <Page date="2021-02-21" onChangeDate={mockFn} />
+  <Page
+    loading={false}
+    date="2021-02-21"
+    onChangeDate={mockFn}
+    title="本を読んだ"
+    categoryID={1}
+  />
 ));

--- a/src/hooks/useUser.tsx
+++ b/src/hooks/useUser.tsx
@@ -45,7 +45,8 @@ const useUser = () => {
       if (userID.contents) {
         setup(userID.contents);
       }
-      setLoading(false);
+
+      setTimeout(() => setLoading(false), 1);
     }
   }, [userID, setup]);
 

--- a/src/lib/apollo.ts
+++ b/src/lib/apollo.ts
@@ -5,18 +5,23 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const makeApolloClient = async () => {
   const uri = `${process.env.API_HOST}/query`;
+  const uid = await AsyncStorage.getItem('USER_ID');
 
-  const authLink = setContext(async (_, { headers }) => {
-    const ctx = {
-      headers,
-    };
-
-    const uid = await AsyncStorage.getItem('USER_ID');
+  const authLink = setContext((_, { headers }) => {
     if (uid) {
-      ctx.headers.UserID = uid;
+      return {
+        headers: {
+          ...headers,
+          UserID: uid,
+        },
+      };
     }
 
-    return ctx;
+    return {
+      headers: {
+        ...headers,
+      },
+    };
   });
 
   const errorLink = onError((error) => {

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -1,6 +1,9 @@
 export type RootStackParamList = {
   Home: undefined;
-  ItemDetail: undefined;
+  ItemDetail: {
+    id: string;
+    date: string;
+  };
   Memoir: undefined;
   SettingLicence: undefined;
 };

--- a/src/queries/createItem.gql
+++ b/src/queries/createItem.gql
@@ -1,0 +1,12 @@
+mutation CreateItem($input: NewItem!) {
+  createItem(input: $input) {
+    id
+    title
+    date
+    categoryID
+    like
+    dislike
+    createdAt
+    updatedAt
+  }
+}

--- a/src/queries/item.gql
+++ b/src/queries/item.gql
@@ -1,0 +1,12 @@
+query Item($id: ID!) {
+  item(id: $id) {
+    id
+    title
+    categoryID
+    date
+    like
+    dislike
+    createdAt
+    updatedAt
+  }
+}

--- a/src/queries/itemsByDate.gql
+++ b/src/queries/itemsByDate.gql
@@ -1,0 +1,12 @@
+query ItemByDate($date: Time!) {
+  itemsByDate(date: $date) {
+    id
+    title
+    categoryID
+    date
+    like
+    dislike
+    createdAt
+    updatedAt
+  }
+}

--- a/src/queries/itemsByDate.gql
+++ b/src/queries/itemsByDate.gql
@@ -1,4 +1,4 @@
-query ItemByDate($date: Time!) {
+query ItemsByDate($date: Time!) {
   itemsByDate(date: $date) {
     id
     title

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,9 @@
       "storyBookUtils/*": ["src/storyBookUtils/*"],
       "store/*": ["src/store/*"],
       "hooks/*": ["src/hooks/*"],
-      "queries/*": ["src/queries/*"]
-    }
+      "queries/*": ["src/queries/*"],
+      "__mockData__/*": ["src/__mockData__/*"]
+    },
+    "typeRoots": ["node_modules/@types", "src/@types"]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,22 +2,22 @@
 # yarn lockfile v1
 
 
-"@apollo/client@^3.3.11":
-  version "3.3.11"
-  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.3.11.tgz#125051405e83dc899d471d43b79fd6045d92a802"
-  integrity sha512-54+D5FB6RJlQ+g37f432gaexnyvDsG5X6L9VO5kqN54HJlbF8hCf/8CXtAQEHCWodAwZhy6kOLp2RM96829q3A==
+"@apollo/client@3.2.5":
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.2.5.tgz#24e0a6faa1d231ab44807af237c6227410c75c4d"
+  integrity sha512-zpruxnFMz6K94gs2pqc3sidzFDbQpKT5D6P/J/I9s8ekHZ5eczgnRp6pqXC86Bh7+44j/btpmOT0kwiboyqTnA==
   dependencies:
     "@graphql-typed-document-node/core" "^3.0.0"
     "@types/zen-observable" "^0.8.0"
     "@wry/context" "^0.5.2"
-    "@wry/equality" "^0.3.0"
+    "@wry/equality" "^0.2.0"
     fast-json-stable-stringify "^2.0.0"
-    graphql-tag "^2.12.0"
+    graphql-tag "^2.11.0"
     hoist-non-react-statics "^3.3.2"
-    optimism "^0.14.0"
+    optimism "^0.13.0"
     prop-types "^15.7.2"
     symbol-observable "^2.0.0"
-    ts-invariant "^0.6.0"
+    ts-invariant "^0.4.4"
     tslib "^1.10.0"
     zen-observable "^0.8.14"
 
@@ -3126,11 +3126,6 @@
   dependencies:
     source-map "^0.6.1"
 
-"@types/ungap__global-this@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@types/ungap__global-this/-/ungap__global-this-0.3.1.tgz#18ce9f657da556037a29d50604335614ce703f4c"
-  integrity sha512-+/DsiV4CxXl6ZWefwHZDXSe1Slitz21tom38qPCaG0DYCS1NnDPIQDTKcmQ/tvK/edJUKkmuIDBJbmKDiB0r/g==
-
 "@types/uuid@^8.3.0":
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
@@ -3260,11 +3255,6 @@
   integrity sha512-9JgC82AaQeglebjZMgYR5wgmfUdUc+EitGUUMW8u2nDckaeimzW+VsoLV6FoimPv2id3VQzfjwBxEMVz08ameQ==
   dependencies:
     eslint-visitor-keys "^1.1.0"
-
-"@ungap/global-this@^0.4.2":
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/@ungap/global-this/-/global-this-0.4.4.tgz#8a1b2cfcd3e26e079a847daba879308c924dd695"
-  integrity sha512-mHkm6FvepJECMNthFuIgpAEFmPOk71UyXuIxYfjytvFTnSDBIz7jmViO+LfHI/AjrazWije0PnSP3+/NlwzqtA==
 
 "@unimodules/core@~6.0.0":
   version "6.0.0"
@@ -3440,19 +3430,12 @@
   dependencies:
     tslib "^1.9.3"
 
-"@wry/equality@^0.3.0":
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.3.4.tgz#37f101552b18a046d5c0c06da7b2021b15f72c03"
-  integrity sha512-1gQQhCPenzxw/1HzLlvSIs/59eBHJf9ZDIussjjZhqNSqQuPKQIzN6SWt4kemvlBPDi7RqMuUa03pId7MAE93g==
+"@wry/equality@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.2.0.tgz#a312d1b6a682d0909904c2bcd355b02303104fb7"
+  integrity sha512-Y4d+WH6hs+KZJUC8YKLYGarjGekBrhslDbf/R20oV+AakHPINSitHfDRQz3EGcEWc1luXYNUvMhawWtZVWNGvQ==
   dependencies:
-    tslib "^1.14.1"
-
-"@wry/trie@^0.2.1":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@wry/trie/-/trie-0.2.2.tgz#99f20f0fcbbcda17006069b155c826cbabfc402f"
-  integrity sha512-OxqBB39x6MfHaa2HpMiRMfhuUnQTddD32Ko020eBeJXq87ivX6xnSSnzKHVbA21p7iqBASz8n/07b6W5wW1BVQ==
-  dependencies:
-    tslib "^1.14.1"
+    tslib "^1.9.3"
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -7671,13 +7654,6 @@ graphql-tag@^2.11.0:
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.11.0.tgz#1deb53a01c46a7eb401d6cb59dec86fa1cccbffd"
   integrity sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA==
 
-graphql-tag@^2.12.0:
-  version "2.12.1"
-  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.1.tgz#b065ef885e4800e4afd0842811b718a205f4aa58"
-  integrity sha512-LPewEE1vzGkHnCO8zdOGogKsHHBdtpGyihow1UuMwp6RnZa0lAS7NcbvltLOuo4pi5diQCPASAXZkQq44ffixA==
-  dependencies:
-    tslib "^1.14.1"
-
 graphql-upload@^11.0.0:
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/graphql-upload/-/graphql-upload-11.0.0.tgz#24b245ff18f353bab6715e8a055db9fd73035e10"
@@ -10395,13 +10371,12 @@ opencollective-postinstall@^2.0.2:
   resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz#7a0fff978f6dbfa4d006238fbac98ed4198c3259"
   integrity sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==
 
-optimism@^0.14.0:
-  version "0.14.1"
-  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.14.1.tgz#db35a0c770e16863f6c288f7cf58341a2348db44"
-  integrity sha512-7+1lSN+LJEtaj3uBLLFk8uFCFKy3txLvcvln5Dh1szXjF9yghEMeWclmnk0qdtYZ+lcMNyu48RmQQRw+LRYKSQ==
+optimism@^0.13.0:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.13.2.tgz#002a438b69652bfe8f8754a4493ed35c2e9d9821"
+  integrity sha512-kJkpDUEs/Rp8HsAYYlDzyvQHlT6YZa95P+2GGNR8p/VvsIkt6NilAk7oeTvMRKCq7BeclB7+bmdIexog2859GQ==
   dependencies:
     "@wry/context" "^0.5.2"
-    "@wry/trie" "^0.2.1"
 
 optionator@^0.9.1:
   version "0.9.1"
@@ -13196,20 +13171,11 @@ ts-invariant@^0.3.2:
   dependencies:
     tslib "^1.9.3"
 
-ts-invariant@^0.4.0:
+ts-invariant@^0.4.0, ts-invariant@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.4.4.tgz#97a523518688f93aafad01b0e80eb803eb2abd86"
   integrity sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==
   dependencies:
-    tslib "^1.9.3"
-
-ts-invariant@^0.6.0:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.6.1.tgz#eb4c52b45daaca8367abbfd6cff998ea871d592d"
-  integrity sha512-QQgN33g8E8yrdDuH29HASveLtbzMnRRgWh0i/JNTW4+zcLsdIOnfsgEDi/NKx4UckQyuMFt9Ujm6TWLWQ58Kvg==
-  dependencies:
-    "@types/ungap__global-this" "^0.3.1"
-    "@ungap/global-this" "^0.4.2"
     tslib "^1.9.3"
 
 ts-log@^2.2.3:


### PR DESCRIPTION
## 対応issue

#7 

## 内容

 - [動作](https://youtu.be/YgAp5-5I0kU)
 - [itemsのGraphQLを作成](https://github.com/wheatandcat/memoir-backend/issues/3)を作成したのでAPIまで接続