### PR TITLE
ホーム画面で月を変更した時に日付が更新されない

### DIFF
--- a/src/components/organisms/DateInput/DateInput.tsx
+++ b/src/components/organisms/DateInput/DateInput.tsx
@@ -111,7 +111,12 @@ const DateInput: React.FC<Props> = (props) => {
 
   const onMonth = useCallback(
     (month: string) => {
-      const date = dayjs(state.date).format(`YYYY-${month}-DD`);
+      let date = dayjs(state.date).format(`YYYY-${month}-DD`);
+
+      if (dayjs(date).month() + 1 !== Number(month)) {
+        // 設定月に、その日が存在しない場合は、月の末日を設定
+        date = dayjs(date).add(-1, 'month').endOf('month').format('YYYY-MM-DD');
+      }
 
       setState((s) => ({ ...s, date }));
     },


### PR DESCRIPTION
## 関連 issue

- fixes #31 

## 対応内容


<img src=https://user-images.githubusercontent.com/19209314/113482124-23d5e800-94d8-11eb-9aba-5e41d1d2a775.gif  width=200>

 * 3月31日のタイミングで4月を選択すると5月1日に遷移するバグがあったので修正（実際は4月31日が設定されるが4月は30日までなので5月1日になっていた）
 * 月の末日を超えていた場合は、その月の末日に設定されるように修正

## 開発用メモ
無し

