### PR TITLE
認証後のAPI設定を追加

### DIFF
--- a/src/components/pages/Login/Connected.tsx
+++ b/src/components/pages/Login/Connected.tsx
@@ -1,25 +1,57 @@
-import React, { memo, useEffect } from 'react';
+import React, { memo, useEffect, useCallback } from 'react';
+import { Alert } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { storageKey } from 'lib/storage';
 import TemplateLogin from 'components/templates/Login/Page';
 import useFirebaseAuth from 'hooks/useFirebaseAuth';
+import useHomeItems from 'hooks/useHomeItems';
 import { useRecoilValue } from 'recoil';
 import { authUserState } from 'store/atoms';
+import {
+  useCreateAuthUserMutation,
+  CreateAuthUserMutationVariables,
+} from 'queries/api/index';
 
 type Props = {};
 
 export type ConnectedType = {};
 
 const Connected: React.FC<Props> = () => {
-  const { setup, onAppleLogin, onGoogleLogin } = useFirebaseAuth();
+  const { setup, onAppleLogin, onGoogleLogin, onLogout } = useFirebaseAuth();
+  const { refetch } = useHomeItems();
   const authUser = useRecoilValue(authUserState);
   const authenticated = !!authUser.uid;
   const navigation = useNavigation();
+  const [createAuthUserMutation] = useCreateAuthUserMutation({
+    async onCompleted() {
+      await refetch?.();
+      navigation.goBack();
+    },
+    async onError() {
+      // エラーになった場合はログアウトさせる
+      Alert.alert('エラー', 'ログインに失敗した');
+      onLogout();
+    },
+  });
+
+  const createAuthUser = useCallback(async () => {
+    const userID = await AsyncStorage.getItem(storageKey.USER_ID_KEY);
+
+    const variables: CreateAuthUserMutationVariables = {
+      input: {
+        id: String(userID),
+      },
+    };
+
+    createAuthUserMutation({ variables });
+  }, [createAuthUserMutation]);
 
   useEffect(() => {
     if (authenticated) {
-      navigation.goBack();
+      createAuthUser();
     }
-  }, [authenticated, navigation]);
+  }, [authenticated, navigation, createAuthUser]);
 
   if (!setup) {
     return null;

--- a/src/hooks/useFirebaseAuth.tsx
+++ b/src/hooks/useFirebaseAuth.tsx
@@ -34,6 +34,7 @@ export type UseFirebaseAuth = ReturnType<typeof useFirebaseAuth>;
 const useFirebaseAuth = () => {
   const authUserID = useRecoilValueLoadable(existAuthUserID);
   const setAuthUser = useSetRecoilState(authUserState);
+
   const [setup, setSetup] = useState(false);
 
   const [request, response, promptAsync] = Google.useIdTokenAuthRequest({

--- a/src/queries/createAuthUser.gql
+++ b/src/queries/createAuthUser.gql
@@ -1,0 +1,5 @@
+mutation CreateAuthUser($input: NewUser!) {
+  createAuthUser(input: $input) {
+    id
+  }
+}


### PR DESCRIPTION
## 関連 issue

- fixes #58 

## 対応内容

 - API側で認証を追加したので、アプリ側でも対応
   - https://github.com/wheatandcat/memoir-backend/pull/23

## 開発用メモ
無し

