### PR TITLE
プロフィール画像アップロード機能実装

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -27,6 +27,10 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     bundleIdentifier: 'com.wheatandcat.memoir',
     infoPlist: {
       CFBundleAllowMixedLocalizations: true,
+      NSPhotoLibraryUsageDescription: 'ユーザーの画像設定に使用します',
+      NSCameraUsageDescription:
+        'ユーザーの画像設定のためにカメラを使用します。',
+      CFBundleDevelopmentRegion: 'ja_JP',
     },
   },
   android: {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@apollo/client": "3.2.5",
     "@expo-google-fonts/inter": "^0.1.0",
+    "@expo/react-native-action-sheet": "^3.9.0",
     "@react-native-async-storage/async-storage": "^1.13.0",
     "@react-native-community/masked-view": "0.1.10",
     "@react-navigation/native": "^5.9.2",
@@ -38,7 +39,10 @@
     "expo-clipboard": "~1.0.2",
     "expo-constants": "~10.1.3",
     "expo-crypto": "~9.1.0",
+    "expo-file-system": "~11.0.2",
     "expo-font": "~9.1.0",
+    "expo-image-manipulator": "~9.1.0",
+    "expo-image-picker": "~10.1.3",
     "expo-linear-gradient": "~9.1.0",
     "expo-linking": "~2.2.3",
     "expo-random": "~11.1.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { RecoilRoot } from 'recoil';
+import { ActionSheetProvider } from '@expo/react-native-action-sheet';
 import { ApolloClient, ApolloProvider } from '@apollo/client';
 import makeApolloClient from 'lib/apollo';
 import useIsFirstRender from 'hooks/useIsFirstRender';
@@ -27,11 +28,13 @@ function App() {
   }
 
   return (
-    <ApolloProvider client={client}>
-      <RecoilRoot>
-        <WithProvider />
-      </RecoilRoot>
-    </ApolloProvider>
+    <ActionSheetProvider>
+      <ApolloProvider client={client}>
+        <RecoilRoot>
+          <WithProvider />
+        </RecoilRoot>
+      </ApolloProvider>
+    </ActionSheetProvider>
   );
 }
 

--- a/src/__mockData__/user.ts
+++ b/src/__mockData__/user.ts
@@ -3,6 +3,7 @@ import { User } from 'queries/api/index';
 export const user = (option?: Partial<User>): User => ({
   id: '1',
   displayName: 'test',
+  image: '',
   updatedAt: '2021-01-01T00:00:00+09:00',
   createdAt: '2021-01-01T00:00:00+09:00',
   ...option,

--- a/src/components/molecules/User/Image.tsx
+++ b/src/components/molecules/User/Image.tsx
@@ -1,0 +1,37 @@
+import React, { memo } from 'react';
+import { StyleSheet } from 'react-native';
+import Image from 'components/atoms/Image';
+
+export type Props = {
+  image: string | null;
+};
+
+const UserImage: React.FC<Props> = (props) => {
+  return (
+    <>
+      {props.image ? (
+        <Image
+          source={{ uri: props.image }}
+          style={styles.image}
+          width={100}
+          height={100}
+          resizeMode="cover"
+        />
+      ) : (
+        <Image
+          source={require('../../../img/icon/icon_account_default.png')}
+          width={100}
+          height={100}
+        />
+      )}
+    </>
+  );
+};
+
+const styles = StyleSheet.create({
+  image: {
+    borderRadius: 60,
+  },
+});
+
+export default memo(UserImage);

--- a/src/components/molecules/User/__tests__/Image.test.tsx
+++ b/src/components/molecules/User/__tests__/Image.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import Image, { Props } from '../Image';
+
+const propsData = (): Props => ({ image: null });
+
+describe('components/molecules/User/Image.tsx', () => {
+  let wrapper: ShallowWrapper;
+
+  beforeEach(() => {
+    wrapper = shallow(<Image {...propsData()} />);
+  });
+
+  it('正常にrenderすること', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/components/molecules/User/__tests__/__snapshots__/Image.test.tsx.snap
+++ b/src/components/molecules/User/__tests__/__snapshots__/Image.test.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/molecules/User/Image.tsx 正常にrenderすること 1`] = `
+<Fragment>
+  <Image
+    height={100}
+    source={null}
+    width={100}
+  />
+</Fragment>
+`;

--- a/src/components/molecules/User/stories.tsx
+++ b/src/components/molecules/User/stories.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react-native';
+import Image, { Props } from './Image';
+
+const props = (): Props => ({ image: null });
+
+storiesOf('molecules/User', module).add('Image', () => <Image {...props()} />);

--- a/src/components/organisms/MyPage/Authenticated.tsx
+++ b/src/components/organisms/MyPage/Authenticated.tsx
@@ -4,8 +4,8 @@ import { MaterialIcons } from '@expo/vector-icons';
 import theme from 'config/theme';
 import View from 'components/atoms/View';
 import Text from 'components/atoms/Text';
-import Image from 'components/atoms/Image';
 import { User } from 'store/atoms';
+import UserImage from 'components/molecules/User/Image';
 
 export type Props = {
   user: User;
@@ -17,7 +17,7 @@ const Authenticated: React.FC<Props> = (props) => {
   return (
     <View style={styles.root}>
       <View mt={4}>
-        <Image source={require('../../../img/icon/icon_account_default.png')} />
+        <UserImage image={props.user.image} />
       </View>
       <View m={4}>
         <TouchableOpacity onPress={props.onUpdateProfile}>

--- a/src/components/organisms/MyPage/__tests__/__snapshots__/Authenticated.test.tsx.snap
+++ b/src/components/organisms/MyPage/__tests__/__snapshots__/Authenticated.test.tsx.snap
@@ -13,8 +13,8 @@ exports[`components/organisms/MyPage/Authenticated.tsx 正常にrenderするこ�
   <View
     mt={4}
   >
-    <Image
-      source={null}
+    <Memo(UserImage)
+      image=""
     />
   </View>
   <View

--- a/src/components/organisms/UpdateProfile/ProfileImage.tsx
+++ b/src/components/organisms/UpdateProfile/ProfileImage.tsx
@@ -1,0 +1,103 @@
+import React, { memo, useState, useCallback } from 'react';
+import { StyleSheet, Alert, TouchableOpacity } from 'react-native';
+import {
+  useActionSheet,
+  connectActionSheet,
+} from '@expo/react-native-action-sheet';
+import * as ImagePicker from 'expo-image-picker';
+import View from 'components/atoms/View';
+import Text from 'components/atoms/Text';
+import theme from 'config/theme';
+import { resizeImage } from 'lib/image';
+import UserImage from 'components/molecules/User/Image';
+
+export type Props = {
+  image: string | null;
+  onChangeImage: (uri: string) => void;
+};
+
+const ProfileImage: React.FC<Props> = (props) => {
+  const [image, setImage] = useState<string | null>(props.image);
+  const { showActionSheetWithOptions } = useActionSheet();
+
+  const pickImageLibrary = useCallback(async () => {
+    const mediaLibrary = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (mediaLibrary.status !== 'granted') {
+      Alert.alert('memoirアプリのカメラのアクセス許可をONにしてください');
+      return;
+    }
+
+    let result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.All,
+      allowsEditing: true,
+      allowMultipleSelection: false,
+      aspect: [1, 1],
+      quality: 1,
+    });
+
+    if (!result.cancelled) {
+      const uri = await resizeImage(result.uri);
+      props.onChangeImage(uri);
+      setImage(uri);
+    }
+  }, [props]);
+
+  const pickImageCamera = useCallback(async () => {
+    const camera = await ImagePicker.requestCameraPermissionsAsync();
+    if (camera.status !== 'granted') {
+      Alert.alert('memoirアプリのカメラのアクセス許可をONにしてください');
+    }
+
+    let result = await ImagePicker.launchCameraAsync({
+      allowsEditing: true,
+      aspect: [1, 1],
+      quality: 1,
+    });
+
+    if (!result.cancelled) {
+      const uri = await resizeImage(result.uri);
+      props.onChangeImage(uri);
+      setImage(uri);
+    }
+  }, [props]);
+
+  const onUpdateImage = useCallback(() => {
+    showActionSheetWithOptions(
+      {
+        options: ['ライブラリから選択', '写真を撮る', 'キャンセル'],
+        cancelButtonIndex: 2,
+      },
+      (buttonIndex) => {
+        if (buttonIndex === 0) {
+          pickImageLibrary();
+        } else if (buttonIndex === 1) {
+          pickImageCamera();
+        }
+      }
+    );
+  }, [showActionSheetWithOptions, pickImageLibrary, pickImageCamera]);
+
+  return (
+    <View style={styles.root}>
+      <View mt={5}>
+        <UserImage image={image} />
+        <View my={3}>
+          <TouchableOpacity onPress={onUpdateImage}>
+            <Text textAlign="center" size="sm">
+              写真を変更
+            </Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  root: {
+    backgroundColor: theme().color.background.main,
+    alignItems: 'center',
+  },
+});
+
+export default connectActionSheet(memo(ProfileImage));

--- a/src/components/organisms/UpdateProfile/__tests__/ProfileImage.test.tsx
+++ b/src/components/organisms/UpdateProfile/__tests__/ProfileImage.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import ProfileImage, { Props } from '../ProfileImage';
+
+const propsData = (): Props => ({
+  image: '',
+  onChangeImage: jest.fn(),
+});
+
+describe('components/organisms/UpdateProfile/ProfileImage.tsx', () => {
+  let wrapper: ShallowWrapper;
+
+  beforeEach(() => {
+    wrapper = shallow(<ProfileImage {...propsData()} />);
+  });
+
+  it('正常にrenderすること', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/components/organisms/UpdateProfile/__tests__/__snapshots__/ProfileImage.test.tsx.snap
+++ b/src/components/organisms/UpdateProfile/__tests__/__snapshots__/ProfileImage.test.tsx.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/organisms/UpdateProfile/ProfileImage.tsx 正常にrenderすること 1`] = `
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
+`;

--- a/src/components/organisms/UpdateProfile/stories.tsx
+++ b/src/components/organisms/UpdateProfile/stories.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react-native';
+import ProfileImage, { Props } from './ProfileImage';
+import { mockFn } from 'storyBookUtils/index';
+
+const props = (): Props => ({
+  image: '',
+  onChangeImage: mockFn('onChangeImage'),
+});
+
+storiesOf('organisms/UpdateProfile', module).add('ProfileImage', () => (
+  <ProfileImage {...props()} />
+));

--- a/src/components/pages/UpdateProfile/Connected.tsx
+++ b/src/components/pages/UpdateProfile/Connected.tsx
@@ -8,11 +8,14 @@ import {
   useUpdateUserMutation,
   UpdateUserMutationVariables,
 } from 'queries/api/index';
+import { uploadImageAsync } from 'lib/image';
+import { User } from 'queries/api/index';
 
 export type Props = {};
 
 type Input = {
   displayName: string;
+  image: string;
 };
 
 export type ConnectedType = {
@@ -24,9 +27,17 @@ const Connected: React.FC<Props> = () => {
   const navigation = useNavigation();
   const [updateUserMutation, updateUserMutationData] = useUpdateUserMutation({
     async onCompleted(data) {
+      const param: Partial<User> = {
+        displayName: data.updateUser.displayName,
+      };
+
+      if (data.updateUser.image !== '') {
+        param.image = data.updateUser.image;
+      }
+
       setUser((s) => ({
         ...s,
-        displayName: data.updateUser.displayName,
+        ...param,
       }));
 
       navigation.goBack();
@@ -40,12 +51,20 @@ const Connected: React.FC<Props> = () => {
   const onSave = useCallback(
     async (input: Input) => {
       const variables: UpdateUserMutationVariables = {
-        input: input,
+        input: {
+          displayName: input.displayName,
+          image: '',
+        },
       };
+
+      if (input.image !== '' && user.image !== input.image) {
+        const image = await uploadImageAsync(input.image);
+        variables.input.image = image;
+      }
 
       updateUserMutation({ variables });
     },
-    [updateUserMutation]
+    [updateUserMutation, user.image]
   );
 
   return (

--- a/src/components/templates/UpdateProfile/Page.tsx
+++ b/src/components/templates/UpdateProfile/Page.tsx
@@ -1,9 +1,9 @@
 import React, { memo, useState } from 'react';
 import { StyleSheet } from 'react-native';
 import { ConnectedType } from 'components/pages/UpdateProfile/Connected';
+import ProfileImage from 'components/organisms/UpdateProfile/ProfileImage';
 import View from 'components/atoms/View';
 import Text from 'components/atoms/Text';
-import Image from 'components/atoms/Image';
 import Button from 'components/atoms/Button';
 import TextInput from 'components/atoms/TextInput';
 import theme from 'config/theme';
@@ -16,10 +16,12 @@ export type Props = ConnectedType & {
 
 type State = {
   displayName: string;
+  image: string;
 };
 
 const initialState = (user: User) => ({
   displayName: user.displayName,
+  image: user.image,
 });
 
 const Page: React.FC<Props> = (props) => {
@@ -27,19 +29,10 @@ const Page: React.FC<Props> = (props) => {
 
   return (
     <View style={styles.root}>
-      <View mt={5}>
-        <Image
-          source={require('../../../img/icon/icon_account_default.png')}
-          width={125}
-          height={125}
-          resizeMode="contain"
-        />
-        <View my={3}>
-          <Text textAlign="center" size="sm">
-            写真を変更
-          </Text>
-        </View>
-      </View>
+      <ProfileImage
+        image={props.user.image}
+        onChangeImage={(uri) => setState((s) => ({ ...s, image: uri }))}
+      />
       <View style={styles.inputContainer}>
         <TextInput
           placeholder="表示名"

--- a/src/components/templates/UpdateProfile/__tests__/Page.test.tsx
+++ b/src/components/templates/UpdateProfile/__tests__/Page.test.tsx
@@ -7,6 +7,7 @@ const propsData = (): Props => ({
   user: {
     id: 'test-id',
     displayName: 'test-name',
+    image: '',
   },
   onSave: jest.fn(),
 });

--- a/src/components/templates/UpdateProfile/__tests__/__snapshots__/Page.test.tsx.snap
+++ b/src/components/templates/UpdateProfile/__tests__/__snapshots__/Page.test.tsx.snap
@@ -10,28 +10,10 @@ exports[`components/templates/UpdateProfile/Page.tsx 正常にrenderすること
     }
   }
 >
-  <View
-    mt={5}
-  >
-    <Image
-      height={125}
-      resizeMode="contain"
-      source={null}
-      width={125}
-    />
-    <View
-      my={3}
-    >
-      <Text
-        fontFamily="RobotoCondensed-Bold"
-        size="sm"
-        textAlign="center"
-        variants="body"
-      >
-        写真を変更
-      </Text>
-    </View>
-  </View>
+  <ConnectedActionSheet
+    image=""
+    onChangeImage={[Function]}
+  />
   <View
     style={
       Object {

--- a/src/components/templates/UpdateProfile/stories.tsx
+++ b/src/components/templates/UpdateProfile/stories.tsx
@@ -7,6 +7,7 @@ const props = (): Props => ({
   user: {
     id: 'test-id',
     displayName: 'test-name',
+    image: '',
   },
   loading: false,
   onSave: mockFn('onSave'),

--- a/src/hooks/useFirebaseAuth.tsx
+++ b/src/hooks/useFirebaseAuth.tsx
@@ -1,8 +1,7 @@
-// FIXME: useIdTokenAuthRequestとRN debuggerを同時に使用するとエラーになるので開発時はこちらを使用
-// @see: https://github.com/expo/expo/issues/12712
-
 import * as AppleAuthentication from 'expo-apple-authentication';
 import * as WebBrowser from 'expo-web-browser';
+import * as Google from 'expo-auth-session/providers/google';
+import { ResponseType } from 'expo-auth-session';
 import * as Crypto from 'expo-crypto';
 import { useRecoilValueLoadable, useRecoilState } from 'recoil';
 import { useCallback, useEffect, useState } from 'react';
@@ -38,8 +37,14 @@ const useFirebaseAuth = () => {
 
   const [setup, setSetup] = useState(false);
 
-  const request = {};
-  const onGoogleLogin = useCallback(() => {}, []);
+  const [request, response, promptAsync] = Google.useIdTokenAuthRequest({
+    responseType: ResponseType.IdToken,
+    expoClientId: process.env.EXPO_GOOGLE_CLIENT_ID,
+  });
+
+  const onGoogleLogin = useCallback(() => {
+    promptAsync();
+  }, [promptAsync]);
 
   const setSession = useCallback(
     async (refresh = false) => {
@@ -72,6 +77,17 @@ const useFirebaseAuth = () => {
     },
     [setSession]
   );
+
+  useEffect(() => {
+    if (response?.type === 'success') {
+      const { id_token } = response.params;
+      const credential = firebase.auth.GoogleAuthProvider.credential(id_token);
+      firebaseLogin(credential);
+    } else if (response?.type === 'error') {
+      console.log('error:', response);
+      Alert.alert('ログインに失敗しました');
+    }
+  }, [response, firebaseLogin]);
 
   const onAppleLogin = useCallback(async () => {
     const nonce = nonceGen(32);

--- a/src/hooks/useFirebaseAuth.tsx
+++ b/src/hooks/useFirebaseAuth.tsx
@@ -1,7 +1,8 @@
+// FIXME: useIdTokenAuthRequestとRN debuggerを同時に使用するとエラーになるので開発時はこちらを使用
+// @see: https://github.com/expo/expo/issues/12712
+
 import * as AppleAuthentication from 'expo-apple-authentication';
 import * as WebBrowser from 'expo-web-browser';
-import * as Google from 'expo-auth-session/providers/google';
-import { ResponseType } from 'expo-auth-session';
 import * as Crypto from 'expo-crypto';
 import { useRecoilValueLoadable, useRecoilState } from 'recoil';
 import { useCallback, useEffect, useState } from 'react';
@@ -37,14 +38,8 @@ const useFirebaseAuth = () => {
 
   const [setup, setSetup] = useState(false);
 
-  const [request, response, promptAsync] = Google.useIdTokenAuthRequest({
-    responseType: ResponseType.IdToken,
-    expoClientId: process.env.EXPO_GOOGLE_CLIENT_ID,
-  });
-
-  const onGoogleLogin = useCallback(() => {
-    promptAsync();
-  }, [promptAsync]);
+  const request = {};
+  const onGoogleLogin = useCallback(() => {}, []);
 
   const setSession = useCallback(
     async (refresh = false) => {
@@ -77,17 +72,6 @@ const useFirebaseAuth = () => {
     },
     [setSession]
   );
-
-  useEffect(() => {
-    if (response?.type === 'success') {
-      const { id_token } = response.params;
-      const credential = firebase.auth.GoogleAuthProvider.credential(id_token);
-      firebaseLogin(credential);
-    } else if (response?.type === 'error') {
-      console.log('error:', response);
-      Alert.alert('ログインに失敗しました');
-    }
-  }, [response, firebaseLogin]);
 
   const onAppleLogin = useCallback(async () => {
     const nonce = nonceGen(32);

--- a/src/hooks/useUser.tsx
+++ b/src/hooks/useUser.tsx
@@ -19,7 +19,7 @@ const useUser = () => {
   const [createUserMutation] = useCreateUserMutation({
     async onCompleted({ createUser }) {
       await AsyncStorage.setItem(storageKey.USER_ID_KEY, createUser.id);
-      setUser({ id: createUser.id, displayName: '' });
+      setUser({ id: createUser.id, displayName: '', image: '' });
     },
   });
 
@@ -42,7 +42,7 @@ const useUser = () => {
         return;
       }
       getUser();
-      setUser({ id, displayName: '' });
+      setUser({ id, displayName: '', image: '' });
     },
     [setUser, user.id, getUser]
   );
@@ -63,6 +63,7 @@ const useUser = () => {
         setUser((s) => ({
           ...s,
           displayName: userUserQuery.data?.user?.displayName || '',
+          image: userUserQuery.data?.user?.image || '',
         }));
       }
     }

--- a/src/lib/image.ts
+++ b/src/lib/image.ts
@@ -1,0 +1,49 @@
+import firebase from 'lib/system/firebase';
+import 'lib/firebase';
+import * as ImageManipulator from 'expo-image-manipulator';
+import { v4 as uuidv4 } from 'uuid';
+import * as FileSystem from 'expo-file-system';
+
+export const uploadImageAsync = async (uri: string): Promise<string> => {
+  console.log('uri:', uri);
+
+  const blob: any = await new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.onload = function () {
+      resolve(xhr.response);
+    };
+    xhr.onerror = function (e) {
+      console.log(e);
+      reject(new TypeError('Network request failed'));
+    };
+    xhr.responseType = 'blob';
+    xhr.open('GET', uri, true);
+    xhr.send(null);
+  });
+
+  const ref = firebase.storage().ref().child(uuidv4());
+  const snapshot = await ref.put(blob);
+
+  blob.close();
+
+  return await snapshot.ref.getDownloadURL();
+};
+
+export const resizeImage = async (uri: string): Promise<string> => {
+  const result = await ImageManipulator.manipulateAsync(
+    uri,
+    [
+      {
+        resize: {
+          width: 500,
+        },
+      },
+    ],
+    { compress: 0, format: ImageManipulator.SaveFormat.PNG }
+  );
+
+  const fileInfo = await FileSystem.getInfoAsync(result.uri);
+  console.log('file-size:', fileInfo.size);
+
+  return result.uri;
+};

--- a/src/queries/updateUser.gql
+++ b/src/queries/updateUser.gql
@@ -2,5 +2,6 @@ mutation UpdateUser($input: UpdateUser!) {
   updateUser(input: $input) {
     id
     displayName
+    image
   }
 }

--- a/src/queries/user.gql
+++ b/src/queries/user.gql
@@ -2,5 +2,6 @@ query User {
   user {
     id
     displayName
+    image
   }
 }

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -12,11 +12,13 @@ dayjs.extend(advancedFormat);
 export type User = {
   id: string | null;
   displayName: string;
+  image: string;
 };
 
 const initialUserState = (): User => ({
   id: null,
   displayName: '',
+  image: '',
 });
 
 export const userState = atom<User>({

--- a/storybook/index.js
+++ b/storybook/index.js
@@ -8,6 +8,7 @@ import {
   addDecorator,
 } from '@storybook/react-native';
 import { withKnobs } from '@storybook/addon-knobs';
+import { ActionSheetProvider } from '@expo/react-native-action-sheet';
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 import { loadStories } from './storyLoader';
@@ -35,17 +36,19 @@ AppRegistry.registerComponent('%APP_NAME%', () => StorybookUIRoot);
 class StorybookUIHMRRoot extends Component {
   render() {
     return (
-      <RecoilRoot>
-        <NavigationContainer independent={true}>
-          <Stack.Navigator>
-            <Stack.Screen
-              name="StorybookUIRoot"
-              component={StorybookUIRoot}
-              options={{ header: () => null }}
-            />
-          </Stack.Navigator>
-        </NavigationContainer>
-      </RecoilRoot>
+      <ActionSheetProvider>
+        <RecoilRoot>
+          <NavigationContainer independent={true}>
+            <Stack.Navigator>
+              <Stack.Screen
+                name="StorybookUIRoot"
+                component={StorybookUIRoot}
+                options={{ header: () => null }}
+              />
+            </Stack.Navigator>
+          </NavigationContainer>
+        </RecoilRoot>
+      </ActionSheetProvider>
     );
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1698,6 +1698,14 @@
     xmlbuilder "^14.0.0"
     xmldom "~0.5.0"
 
+"@expo/react-native-action-sheet@^3.9.0":
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/@expo/react-native-action-sheet/-/react-native-action-sheet-3.9.0.tgz#6f94f21fc1948e473589adb28cc4db7e48cee5bf"
+  integrity sha512-SCduO7QHhDMP/MCicWfYERcDMNfP0tirymj/MLEvYC/OWAT/28GUzSoxlQXjhtH+b9lVoJfmh45kwSY0ExPsXQ==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.1"
+    hoist-non-react-statics "^3.3.0"
+
 "@expo/spawn-async@1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@expo/spawn-async/-/spawn-async-1.5.0.tgz#799827edd8c10ef07eb1a2ff9dcfe081d596a395"
@@ -3789,6 +3797,14 @@
   version "2.0.39"
   resolved "https://registry.yarnpkg.com/@types/hammerjs/-/hammerjs-2.0.39.tgz#4be64bbacf3813c79c0dab895c6b0fdc7d5e513f"
   integrity sha512-lYR2Y/tV2ujpk/WyUc7S0VLI0a9hrtVIN9EwnrNo5oSEJI2cK2/XrgwOQmXLL3eTulOESvh9qP6si9+DWM9cOA==
+
+"@types/hoist-non-react-statics@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
 
 "@types/html-minifier-terser@^5.0.0":
   version "5.1.1"
@@ -8200,6 +8216,21 @@ expo-font@~9.1.0:
   dependencies:
     fontfaceobserver "^2.1.0"
 
+expo-image-manipulator@~9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/expo-image-manipulator/-/expo-image-manipulator-9.1.0.tgz#c1bac33c071e116a97a654f9f11bf50f7ff8932c"
+  integrity sha512-jguMQ3k63JJwxo1mAsLRa+lXbH9fVsQXKbOfwY5KKXvNld7aaRgCO6pWnrBfCxvKkU4KhVp9JWOrsz4qcnYQ2w==
+
+expo-image-picker@~10.1.3:
+  version "10.1.4"
+  resolved "https://registry.yarnpkg.com/expo-image-picker/-/expo-image-picker-10.1.4.tgz#5805ea365385298cd59315790481a0a8d6c6a9ef"
+  integrity sha512-4U16RteJNWP5mC198fOIK/BgI3ZXRjqwslFK/gUrKiK5QKECXdvPCHrPwbXlo1DRQNhoPvWd+Cnhod0RsDnMkQ==
+  dependencies:
+    "@expo/config-plugins" "^1.0.18"
+    expo-permissions "~12.0.1"
+    unimodules-permissions-interface "~6.1.0"
+    uuid "7.0.2"
+
 expo-keep-awake@~9.1.2:
   version "9.1.2"
   resolved "https://registry.yarnpkg.com/expo-keep-awake/-/expo-keep-awake-9.1.2.tgz#b3e52c7bef0ade975ae88637a2bf980f6b573368"
@@ -8219,6 +8250,11 @@ expo-linking@~2.2.3:
     invariant "^2.2.4"
     qs "^6.5.0"
     url-parse "^1.4.4"
+
+expo-permissions@~12.0.1:
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/expo-permissions/-/expo-permissions-12.0.1.tgz#5163c00d991bf565bf987354611628c298ddd0c4"
+  integrity sha512-TtypNPPLG4SdVEKBlrArLLZIyhlhE+3B4dhz2HaY1Mve2rcvKE0C7z/e1WoUVU8+LgcdKoNGwg/wRVeCkxeEhg==
 
 expo-random@~11.1.2:
   version "11.1.2"
@@ -16692,6 +16728,11 @@ unicode-property-aliases-ecmascript@^1.0.4:
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz#dd57a99f6207bedff4628abefb94c50db941c8f4"
   integrity sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==
 
+unimodules-permissions-interface@~6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/unimodules-permissions-interface/-/unimodules-permissions-interface-6.1.0.tgz#fd5589945e3b8fc9d2c80c52521853caea85a9ca"
+  integrity sha512-jeJx/y+Vn/Cp1/4su5XJ06UBul83MpXkYEqIOAb2jwaikhmj6tNwko7HpKy9OhfGfrhddCzwtedlro8xxZUk9A==
+
 union-value@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.1.tgz#0b6fe7b835aecda61c6ea4d4f02c14221e109847"
@@ -16922,6 +16963,11 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
+
+uuid@7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.2.tgz#7ff5c203467e91f5e0d85cfcbaaf7d2ebbca9be6"
+  integrity sha512-vy9V/+pKG+5ZTYKf+VcphF5Oc6EFiu3W8Nv3P3zIh0EqVI80ZxOzuPfe9EHjkFNvf8+xuTHVeei4Drydlx4zjw==
 
 uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"


### PR DESCRIPTION
## 関連 issue

- fixes #67 

## 対応内容

<div>
<img src=https://user-images.githubusercontent.com/19209314/118398157-4db32a80-b692-11eb-8441-12757a8b39d2.png  width=200>
<img src=https://user-images.githubusercontent.com/19209314/118398158-4f7cee00-b692-11eb-95e4-e5f183fdc07e.png  width=200>
<img src=https://user-images.githubusercontent.com/19209314/118398159-50ae1b00-b692-11eb-8827-2dae3a9e1de9.png  width=200>
<img src=https://user-images.githubusercontent.com/19209314/118398161-51df4800-b692-11eb-8f12-7da6bdc545ec.png  width=200>
</div>

 - プロフィール変更画面から画像アップロード機能を実装
 - 画像選択/カメラは[expo-image-picker](https://docs.expo.io/versions/latest/sdk/imagepicker/)を使用
 - 画像のresizeは[expo-image-manipulator](https://docs.expo.io/versions/latest/sdk/imagemanipulator/)を使用
 - アップロードは[Firebase Storage](https://github.com/expo/examples/tree/master/with-firebase-storage-upload)を使用

## 開発用メモ
無し

