### PR TITLE
memoirするにユーザー情報の表示を追加

### DIFF
--- a/src/components/organisms/AddShareUser/__tests__/InviteCard.test.tsx
+++ b/src/components/organisms/AddShareUser/__tests__/InviteCard.test.tsx
@@ -9,7 +9,10 @@ const propsData = (): Props => ({
   creating: false,
   updating: false,
   invite: invite(),
-  user: user(),
+  user: {
+    ...user(),
+    userID: '',
+  },
   onCreateInvite: jest.fn(),
   onUpdateInvite: jest.fn(),
 });

--- a/src/components/organisms/AddShareUser/stories.tsx
+++ b/src/components/organisms/AddShareUser/stories.tsx
@@ -13,7 +13,10 @@ const inviteCardProps = (): InviteCardProps => ({
   creating: false,
   updating: false,
   invite: invite(),
-  user: user(),
+  user: {
+    ...user(),
+    userID: '',
+  },
   onCreateInvite: mockFn('onCreateInvite'),
   onUpdateInvite: mockFn('onUpdateInvite'),
 });

--- a/src/components/organisms/Memoir/Card.tsx
+++ b/src/components/organisms/Memoir/Card.tsx
@@ -9,13 +9,14 @@ import View from 'components/atoms/View';
 import Text from 'components/atoms/Text';
 import Category from 'components/atoms/Category';
 import theme from 'config/theme';
-import Image from 'components/atoms/Image';
 import IconButton from 'components/molecules/IconButton';
 import { Item } from 'queries/api/index';
+import UserImage from 'components/molecules/User/Image';
 
 type User = {
   id: string;
-  name: string;
+  displayName: string;
+  image: string;
 };
 
 export type Props = {
@@ -45,13 +46,9 @@ const Card: React.FC<Props> = (props) => {
             </Text>
           </View>
           <View style={styles.user}>
-            <Image
-              source={require('../../../img/icon/account.png')}
-              width={20}
-              height={20}
-            />
+            <UserImage image={props.user.image} size={20} />
             <View pl={2}>
-              <Text variants="small">{props.user?.name}</Text>
+              <Text variants="small">{props.user?.displayName}</Text>
             </View>
           </View>
         </View>

--- a/src/components/organisms/Memoir/DateCards.tsx
+++ b/src/components/organisms/Memoir/DateCards.tsx
@@ -21,7 +21,7 @@ type Item = ArrayType<PlainProps['items']>;
 
 export type Props = Pick<
   PlainProps,
-  'items' | 'loading' | 'onLoadMore' | 'onItem' | 'pageInfo'
+  'items' | 'loading' | 'onLoadMore' | 'onItem' | 'pageInfo' | 'users'
 > & {
   startDate: string;
   endDate: string;
@@ -29,7 +29,8 @@ export type Props = Pick<
 
 type User = {
   id: string;
-  name: string;
+  displayName: string;
+  image: string;
 };
 
 type Card = Item & {
@@ -104,21 +105,29 @@ const DateCards: React.FC<Props> = (props) => {
 
   const data = dateItems
     .map((v1) => {
-      const user = { id: 'test', name: 'Nameless' };
-
       const sameDateItems = props.items.filter(
         (v2) => dayjs(v2.date).format('YYYY-MM-DD') === v1.date
       );
 
-      const item: RenderedItem[] = sameDateItems.map((v2, index) => ({
-        date: null,
-        contents: {
-          ...v2,
-          user,
-        },
-        last: sameDateItems.length === index + 1,
-        width: windowWidth,
-      }));
+      const item: RenderedItem[] = sameDateItems.map((v2, index) => {
+        const user: User | undefined = props.users.find(
+          (v) => v.id === v2.userID
+        );
+
+        return {
+          date: null,
+          contents: {
+            ...v2,
+            user: user || {
+              id: '',
+              displayName: '',
+              image: '',
+            },
+          },
+          last: sameDateItems.length === index + 1,
+          width: windowWidth,
+        };
+      });
 
       const categoryID = item.map((v) => Number(v.contents?.categoryID));
 

--- a/src/components/organisms/Memoir/__tests__/Card.test.tsx
+++ b/src/components/organisms/Memoir/__tests__/Card.test.tsx
@@ -5,7 +5,11 @@ import Card, { Props } from '../Card';
 const propsData = (): Props => ({
   title: 'title',
   categoryID: 1,
-  user: { id: 'test', name: 'test' },
+  user: {
+    id: 'test',
+    displayName: 'suzuki',
+    image: '',
+  },
   onPress: jest.fn(),
 });
 

--- a/src/components/organisms/Memoir/__tests__/__snapshots__/Card.test.tsx.snap
+++ b/src/components/organisms/Memoir/__tests__/__snapshots__/Card.test.tsx.snap
@@ -50,10 +50,9 @@ exports[`components/organisms/Memoir/Card.tsx 正常にrenderすること 1`] = 
           }
         }
       >
-        <Image
-          height={20}
-          source={null}
-          width={20}
+        <Memo(UserImage)
+          image=""
+          size={20}
         />
         <View
           pl={2}
@@ -62,7 +61,7 @@ exports[`components/organisms/Memoir/Card.tsx 正常にrenderすること 1`] = 
             fontFamily="RobotoCondensed-Bold"
             variants="small"
           >
-            test
+            suzuki
           </Text>
         </View>
       </View>

--- a/src/components/organisms/Memoir/stories.tsx
+++ b/src/components/organisms/Memoir/stories.tsx
@@ -9,7 +9,7 @@ import { items, item } from '__mockData__/item';
 import Card from './Card';
 
 const props = (): Props => ({
-  items: items(),
+  items: items().map((v) => ({ ...v, userID: 'test' })),
   pageInfo: {
     hasNextPage: false,
     endCursor: '',
@@ -19,6 +19,13 @@ const props = (): Props => ({
   loading: false,
   startDate: '2020-01-01',
   endDate: '2020-01-07',
+  users: [
+    {
+      id: 'test',
+      displayName: 'suzuki',
+      image: 'https://placehold.jp/150x150.png',
+    },
+  ],
 });
 
 storiesOf('organisms/Memoir/DateCards', module)
@@ -36,7 +43,11 @@ storiesOf('organisms/Memoir/DateCards', module)
 storiesOf('organisms/Memoir', module).add('Card', () => (
   <Card
     {...item()}
-    user={{ id: 'test', name: 'test太郎' }}
+    user={{
+      id: 'test',
+      displayName: 'suzuki',
+      image: 'https://placehold.jp/150x150.png',
+    }}
     onPress={mockFn('onPress')}
   />
 ));

--- a/src/components/organisms/MyPage/__tests__/Authenticated.test.tsx
+++ b/src/components/organisms/MyPage/__tests__/Authenticated.test.tsx
@@ -5,7 +5,10 @@ import { relationships } from '__mockData__/relationship';
 import Authenticated, { Props } from '../Authenticated';
 
 const propsData = (): Props => ({
-  user: user(),
+  user: {
+    ...user(),
+    userID: '',
+  },
   relationships: relationships(),
   relationshipRequestCount: 3,
   onUpdateProfile: jest.fn(),

--- a/src/components/organisms/MyPage/stories.tsx
+++ b/src/components/organisms/MyPage/stories.tsx
@@ -13,7 +13,10 @@ const props1 = (): NotAuthenticatedProps => ({
 });
 
 const props2 = (): AuthenticatedProps => ({
-  user: user(),
+  user: {
+    ...user(),
+    userID: '',
+  },
   relationshipRequestCount: 3,
   relationships: relationships(),
   onLogout: mockFn('onLogout'),

--- a/src/components/organisms/ShareUser/__tests__/User.test.tsx
+++ b/src/components/organisms/ShareUser/__tests__/User.test.tsx
@@ -4,7 +4,10 @@ import { user } from '__mockData__/user';
 import User, { Props } from '../User';
 
 const propsData = (): Props => ({
-  user: user(),
+  user: {
+    ...user(),
+    userID: '',
+  },
   loading: false,
   onDeleteRelationship: jest.fn(),
 });

--- a/src/components/organisms/ShareUser/stories.tsx
+++ b/src/components/organisms/ShareUser/stories.tsx
@@ -14,7 +14,10 @@ const listProps = (): ListProps => ({
 });
 
 const userProps = (): UserProps => ({
-  user: user(),
+  user: {
+    ...user(),
+    userID: '',
+  },
   loading: false,
   onDeleteRelationship: mockFn('onDeleteRelationship'),
 });

--- a/src/components/pages/Memoir/Connected.tsx
+++ b/src/components/pages/Memoir/Connected.tsx
@@ -1,6 +1,11 @@
 import React, { memo, useCallback, useState } from 'react';
-import { useItemsInPeriodQuery } from 'queries/api/index';
+import {
+  useItemsInPeriodQuery,
+  useRelationshipsQuery,
+} from 'queries/api/index';
 import useItemsInPeriodPaging from 'hooks/useItemsInPeriodPaging';
+import { useRecoilValue } from 'recoil';
+import { userState } from 'store/atoms';
 import Plain from './Plain';
 
 type Props = {
@@ -12,9 +17,16 @@ export type State = {
   after: string | null;
 };
 
+type User = {
+  id: string;
+  displayName: string;
+  image: string;
+};
+
 export type ConnectedType = {
   startDate: string;
   endDate: string;
+  users: User[];
   onItem: () => void;
   onLoadMore: (after: string | null) => void;
 };
@@ -25,6 +37,16 @@ const initialState = () => ({
 
 const Connected: React.FC<Props> = (props) => {
   const [state, setState] = useState<State>(initialState());
+  const user = useRecoilValue(userState);
+  const relationshipsQuery = useRelationshipsQuery({
+    variables: {
+      input: {
+        after: '',
+        first: 5,
+      },
+      skip: false,
+    },
+  });
 
   const queryResult = useItemsInPeriodQuery({
     variables: {
@@ -50,11 +72,23 @@ const Connected: React.FC<Props> = (props) => {
 
   const onItem = useCallback(() => {}, []);
 
+  const users: User[] = [
+    { id: user.userID || '', displayName: user.displayName, image: user.image },
+  ];
+
+  const relationships = relationshipsQuery.data?.relationships?.edges || [];
+  const relationshipUsers: User[] = relationships.map((v) => ({
+    id: v?.node?.user?.id || '',
+    displayName: v?.node?.user?.displayName || '',
+    image: v?.node?.user?.image || '',
+  }));
+
   return (
     <Plain
       startDate={props.startDate}
       endDate={props.endDate}
       items={items}
+      users={[...users, ...relationshipUsers]}
       pageInfo={pageInfo}
       onLoadMore={onLoadMore}
       loading={queryResult.loading}

--- a/src/components/pages/Memoir/Plain.tsx
+++ b/src/components/pages/Memoir/Plain.tsx
@@ -26,6 +26,7 @@ const Plain: React.FC<Props> = (props) => {
       loading={props.loading}
       onItem={props.onItem}
       items={props.items}
+      users={props.users}
       onLoadMore={props.onLoadMore}
       pageInfo={props.pageInfo}
     />

--- a/src/components/pages/Setting/AddShareUser/__tests__/Plain.test.tsx
+++ b/src/components/pages/Setting/AddShareUser/__tests__/Plain.test.tsx
@@ -10,7 +10,10 @@ const propsData = (): Props => ({
   data: {
     invite: invite(),
   },
-  user: user(),
+  user: {
+    ...user(),
+    userID: '',
+  },
   creating: false,
   updating: false,
   requesting: false,

--- a/src/components/pages/Setting/AddShareUser/__tests__/__snapshots__/Plain.test.tsx.snap
+++ b/src/components/pages/Setting/AddShareUser/__tests__/__snapshots__/Plain.test.tsx.snap
@@ -31,6 +31,7 @@ exports[`components/pages/Setting/AddShareUser/Plain.tsx 正常にrenderする�
       "id": "1",
       "image": "",
       "updatedAt": "2021-01-01T00:00:00+09:00",
+      "userID": "",
     }
   }
 />

--- a/src/components/templates/Memoir/Page.tsx
+++ b/src/components/templates/Memoir/Page.tsx
@@ -13,7 +13,7 @@ import FocusAwareStatusBar from 'components/organisms/FocusAwareStatusBar';
 
 export type Props = Pick<
   PlainProps,
-  'items' | 'loading' | 'onLoadMore' | 'onItem' | 'pageInfo'
+  'items' | 'loading' | 'onLoadMore' | 'onItem' | 'pageInfo' | 'users'
 > & {
   startDate: string;
   endDate: string;
@@ -38,6 +38,7 @@ const Page: React.FC<Props> = (props) => {
             loading={props.loading}
             onItem={props.onItem}
             onLoadMore={props.onLoadMore}
+            users={props.users}
           />
         </View>
         <View style={styles.action}>

--- a/src/components/templates/Memoir/stories.tsx
+++ b/src/components/templates/Memoir/stories.tsx
@@ -5,7 +5,7 @@ import Page, { Props } from './Page';
 import { items } from '__mockData__/item';
 
 const props = (): Props => ({
-  items: items(),
+  items: items().map((v) => ({ ...v, userID: 'test' })),
   pageInfo: {
     hasNextPage: false,
     endCursor: '',
@@ -15,6 +15,13 @@ const props = (): Props => ({
   loading: false,
   startDate: '2020-01-01',
   endDate: '2020-01-07',
+  users: [
+    {
+      id: 'test',
+      displayName: 'suzuki',
+      image: 'https://placehold.jp/150x150.png',
+    },
+  ],
 });
 
 storiesOf('templates/Memoir', module).add('Page', () => <Page {...props()} />);

--- a/src/components/templates/MyPage/stories.tsx
+++ b/src/components/templates/MyPage/stories.tsx
@@ -11,7 +11,10 @@ const props = (): Props => ({
   onUpdateProfile: mockFn('onUpdateProfile'),
   onAddShareUser: mockFn('onAddShareUser'),
   onRelationshipRequests: mockFn('onRelationshipRequests'),
-  user: user(),
+  user: {
+    ...user(),
+    userID: '',
+  },
   relationshipRequestCount: 3,
   relationships: relationships(),
   deleting: false,

--- a/src/components/templates/Setting/AddShareUser/__tests__/Page.test.tsx
+++ b/src/components/templates/Setting/AddShareUser/__tests__/Page.test.tsx
@@ -6,7 +6,10 @@ import Page, { Props } from '../Page';
 
 const propsData = (): Props => ({
   invite: invite(),
-  user: user(),
+  user: {
+    ...user(),
+    userID: '',
+  },
   loading: false,
   creating: false,
   updating: false,

--- a/src/components/templates/Setting/AddShareUser/__tests__/__snapshots__/Page.test.tsx.snap
+++ b/src/components/templates/Setting/AddShareUser/__tests__/__snapshots__/Page.test.tsx.snap
@@ -50,6 +50,7 @@ exports[`components/templates/Setting/AddShareUser/Page.tsx 正常にrenderす�
             "id": "1",
             "image": "",
             "updatedAt": "2021-01-01T00:00:00+09:00",
+            "userID": "",
           }
         }
       />

--- a/src/components/templates/Setting/AddShareUser/stories.tsx
+++ b/src/components/templates/Setting/AddShareUser/stories.tsx
@@ -7,7 +7,10 @@ import Page, { Props } from './Page';
 
 const props = (): Props => ({
   invite: invite(),
-  user: user(),
+  user: {
+    ...user(),
+    userID: '',
+  },
   loading: false,
   creating: false,
   updating: false,

--- a/src/components/templates/UpdateProfile/__tests__/Page.test.tsx
+++ b/src/components/templates/UpdateProfile/__tests__/Page.test.tsx
@@ -6,6 +6,7 @@ const propsData = (): Props => ({
   loading: false,
   user: {
     id: 'test-id',
+    userID: '',
     displayName: 'test-name',
     image: '',
   },

--- a/src/components/templates/UpdateProfile/stories.tsx
+++ b/src/components/templates/UpdateProfile/stories.tsx
@@ -6,6 +6,7 @@ import Page, { Props } from './Page';
 const props = (): Props => ({
   user: {
     id: 'test-id',
+    userID: '',
     displayName: 'test-name',
     image: '',
   },

--- a/src/hooks/useUser.tsx
+++ b/src/hooks/useUser.tsx
@@ -19,7 +19,7 @@ const useUser = () => {
   const [createUserMutation] = useCreateUserMutation({
     async onCompleted({ createUser }) {
       await AsyncStorage.setItem(storageKey.USER_ID_KEY, createUser.id);
-      setUser({ id: createUser.id, displayName: '', image: '' });
+      setUser({ id: createUser.id, userID: '', displayName: '', image: '' });
     },
   });
 
@@ -42,7 +42,8 @@ const useUser = () => {
         return;
       }
       getUser();
-      setUser({ id, displayName: '', image: '' });
+
+      setUser({ id, userID: '', displayName: '', image: '' });
     },
     [setUser, user.id, getUser]
   );
@@ -62,6 +63,7 @@ const useUser = () => {
       if (userUserQuery.data?.user?.id) {
         setUser((s) => ({
           ...s,
+          userID: userUserQuery.data?.user?.id || '',
           displayName: userUserQuery.data?.user?.displayName || '',
           image: userUserQuery.data?.user?.image || '',
         }));

--- a/src/queries/itemsInPeriod.gql
+++ b/src/queries/itemsInPeriod.gql
@@ -13,6 +13,7 @@ query ItemsInPeriod($input: InputItemsInPeriod!) {
         createdAt
         like
         id
+        userID
       }
       cursor
     }

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -6,12 +6,14 @@ export type Item = NonNullable<ItemQuery['item']>;
 
 export type User = {
   id: string | null;
+  userID: string;
   displayName: string;
   image: string;
 };
 
 const initialUserState = (): User => ({
   id: null,
+  userID: '',
   displayName: '',
   image: '',
 });


### PR DESCRIPTION
## 関連 issue

- fixes #72 

## 対応内容
<img src=https://user-images.githubusercontent.com/19209314/122243985-8186a780-ceff-11eb-9ab0-6402628af38a.png  width=200>

 - memoirするの画面にユーザー情報を追加

## 開発用メモ
無し

