### PR TITLE
memoirするの画面にフィルター機能を追加

### DIFF
--- a/src/components/molecules/Memoir/Header.tsx
+++ b/src/components/molecules/Memoir/Header.tsx
@@ -8,16 +8,19 @@ import theme from 'config/theme';
 export type Props = {
   startDate: string;
   endDate: string;
+  isTitle?: boolean;
 };
 
 const Header: React.FC<Props> = (props) => {
   return (
     <View style={styles.root}>
-      <View>
-        <Text variants="logo" textAlign="center">
-          memoir
-        </Text>
-      </View>
+      {!!props.isTitle && (
+        <View>
+          <Text variants="logo" textAlign="center">
+            memoir
+          </Text>
+        </View>
+      )}
       <View style={styles.date}>
         <Text variants="middle" textAlign="center" color="baseLight">
           {dayjs(props.startDate).format('YYYY.MM.DD')} -{' '}

--- a/src/components/molecules/Memoir/Users.tsx
+++ b/src/components/molecules/Memoir/Users.tsx
@@ -1,0 +1,85 @@
+import React, { memo, useCallback } from 'react';
+import { StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
+import View from 'components/atoms/View';
+import theme from 'config/theme';
+import { User } from 'queries/api/index';
+import UserImage from 'components/molecules/User/Image';
+import { Props as PlainProps } from 'components/pages/Memoir/Plain';
+
+type Users = Pick<User, 'id' | 'image'>[];
+
+export type Props = {
+  users: Users;
+  selectedUserIDList: PlainProps['selectedUserIDList'];
+  onChangeUserID: PlainProps['onChangeUserID'];
+};
+
+const Users: React.FC<Props> = (props) => {
+  const onAdd = useCallback(
+    (uid: string) => {
+      const userIDList = [...props.selectedUserIDList, uid];
+      props.onChangeUserID(userIDList);
+    },
+    [props]
+  );
+
+  const onRemove = useCallback(
+    (uid: string) => {
+      const userIDList = props.selectedUserIDList.filter((v) => v !== uid);
+      props.onChangeUserID(userIDList);
+    },
+    [props]
+  );
+
+  return (
+    <ScrollView style={styles.wrap} horizontal>
+      <View style={styles.root}>
+        {props.users.map((v) => {
+          const selected = props.selectedUserIDList.find((uid) => v.id === uid);
+
+          if (selected) {
+            if (props.selectedUserIDList.length === 1) {
+              return (
+                <View key={v.id} m={2}>
+                  <UserImage size={70} image={v.image} />
+                </View>
+              );
+            }
+
+            return (
+              <View key={v.id} m={2}>
+                <TouchableOpacity onPress={() => onRemove(v.id)}>
+                  <UserImage size={70} image={v.image} />
+                </TouchableOpacity>
+              </View>
+            );
+          }
+
+          return (
+            <View key={v.id} m={2} style={styles.clear}>
+              <TouchableOpacity onPress={() => onAdd(v.id)}>
+                <UserImage size={70} image={v.image} />
+              </TouchableOpacity>
+            </View>
+          );
+        })}
+      </View>
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  root: {
+    backgroundColor: theme().color.background.main,
+    flexDirection: 'row',
+    marginLeft: theme().space(4),
+  },
+  wrap: {
+    flex: 1,
+  },
+  clear: {
+    opacity: 0.4,
+  },
+});
+
+export default memo(Users);

--- a/src/components/molecules/Memoir/__tests__/Users.test.tsx
+++ b/src/components/molecules/Memoir/__tests__/Users.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import Users, { Props } from '../Users';
+
+const propsData = (): Props => ({
+  selectedUserIDList: ['test'],
+  onChangeUserID: jest.fn(),
+  users: [
+    {
+      id: 'test',
+      image: 'https://placehold.jp/150x150.png',
+    },
+  ],
+});
+
+describe('components/molecules/Memoir/Users.tsx', () => {
+  let wrapper: ShallowWrapper;
+
+  beforeEach(() => {
+    wrapper = shallow(<Users {...propsData()} />);
+  });
+
+  it('正常にrenderすること', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/components/molecules/Memoir/__tests__/__snapshots__/Header.test.tsx.snap
+++ b/src/components/molecules/Memoir/__tests__/__snapshots__/Header.test.tsx.snap
@@ -9,15 +9,6 @@ exports[`components/molecules/Memoir/Header.tsx 正常にrenderすること 1`] 
     }
   }
 >
-  <View>
-    <Text
-      fontFamily="RobotoCondensed-Bold"
-      textAlign="center"
-      variants="logo"
-    >
-      memoir
-    </Text>
-  </View>
   <View
     style={
       Object {

--- a/src/components/molecules/Memoir/__tests__/__snapshots__/Users.test.tsx.snap
+++ b/src/components/molecules/Memoir/__tests__/__snapshots__/Users.test.tsx.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/molecules/Memoir/Users.tsx 正常にrenderすること 1`] = `
+<ScrollView
+  horizontal={true}
+  style={
+    Object {
+      "flex": 1,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "backgroundColor": "#F2F2F2",
+        "flexDirection": "row",
+        "marginLeft": 32,
+      }
+    }
+  >
+    <View
+      key="test"
+      m={2}
+    >
+      <Memo(UserImage)
+        image="https://placehold.jp/150x150.png"
+        size={70}
+      />
+    </View>
+  </View>
+</ScrollView>
+`;

--- a/src/components/molecules/Memoir/stories.tsx
+++ b/src/components/molecules/Memoir/stories.tsx
@@ -1,12 +1,41 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react-native';
-import Header, { Props } from './Header';
+import { mockFn } from 'storyBookUtils/index';
+import Header, { Props as HeaderProps } from './Header';
+import Users, { Props as UsersProps } from './Users';
 
-const props = (): Props => ({
+const headerProps = (): HeaderProps => ({
   startDate: '2020-01-01',
   endDate: '2020-01-07',
 });
 
-storiesOf('molecules/Memoir', module).add('Header', () => (
-  <Header {...props()} />
-));
+const userProps = (): UsersProps => ({
+  users: [
+    {
+      id: '1',
+      image: 'http://placehold.jp/150x150.png',
+    },
+    {
+      id: '2',
+      image: 'http://placehold.jp/250x250.png',
+    },
+    {
+      id: '3',
+      image: 'http://placehold.jp/150x150.png',
+    },
+    {
+      id: '4',
+      image: 'http://placehold.jp/250x250.png',
+    },
+    {
+      id: '5',
+      image: 'http://placehold.jp/150x150.png',
+    },
+  ],
+  selectedUserIDList: ['1'],
+  onChangeUserID: mockFn('onChangeUserID'),
+});
+
+storiesOf('molecules/Memoir', module)
+  .add('Header', () => <Header {...headerProps()} />)
+  .add('Users', () => <Users {...userProps()} />);

--- a/src/components/organisms/Memoir/DateCards.tsx
+++ b/src/components/organisms/Memoir/DateCards.tsx
@@ -15,13 +15,21 @@ import theme from 'config/theme';
 import { getModeCountMax } from 'lib/utility';
 import Divider from 'components/atoms/Divider';
 import Image from 'components/atoms/Image';
+import Users from 'components/molecules/Memoir/Users';
 import Card from './Card';
 
 type Item = ArrayType<PlainProps['items']>;
 
 export type Props = Pick<
   PlainProps,
-  'items' | 'loading' | 'onLoadMore' | 'onItem' | 'pageInfo' | 'users'
+  | 'items'
+  | 'loading'
+  | 'onLoadMore'
+  | 'onItem'
+  | 'pageInfo'
+  | 'users'
+  | 'selectedUserIDList'
+  | 'onChangeUserID'
 > & {
   startDate: string;
   endDate: string;
@@ -155,6 +163,8 @@ const DateCards: React.FC<Props> = (props) => {
     props.onLoadMore(props?.pageInfo.endCursor);
   }, [props]);
 
+  const isUserFilter = props.users.length > 1;
+
   return (
     <View style={styles.root}>
       <FlatList<RenderedItem>
@@ -162,7 +172,20 @@ const DateCards: React.FC<Props> = (props) => {
         data={data}
         renderItem={renderItemCall}
         ListHeaderComponent={
-          <Header startDate={props.startDate} endDate={props.endDate} />
+          <View style={styles.header}>
+            {isUserFilter && (
+              <Users
+                users={props.users}
+                selectedUserIDList={props.selectedUserIDList}
+                onChangeUserID={props.onChangeUserID}
+              />
+            )}
+            <Header
+              startDate={props.startDate}
+              endDate={props.endDate}
+              isTitle={!isUserFilter}
+            />
+          </View>
         }
         ListFooterComponent={<ListFooterComponent loading={props.loading} />}
         onEndReachedThreshold={0.8}
@@ -181,5 +204,8 @@ const styles = StyleSheet.create({
   footer: {
     paddingTop: theme().space(2),
     height: 200,
+  },
+  header: {
+    flex: 1,
   },
 });

--- a/src/components/organisms/Memoir/ScreenShot.tsx
+++ b/src/components/organisms/Memoir/ScreenShot.tsx
@@ -176,7 +176,7 @@ const ScreenShot: React.FC<Props> = (props) => {
     <>
       <ScrollView style={styles.root}>
         <ViewShot ref={viewShot} options={{ format: 'jpg' }}>
-          <Header startDate={props.startDate} endDate={props.endDate} />
+          <Header startDate={props.startDate} endDate={props.endDate} isTitle />
           {data.map((v, index) => (
             <RenderItem {...v} key={index} />
           ))}

--- a/src/components/organisms/Memoir/__tests__/__snapshots__/ScreenShot.test.tsx.snap
+++ b/src/components/organisms/Memoir/__tests__/__snapshots__/ScreenShot.test.tsx.snap
@@ -21,6 +21,7 @@ exports[`components/organisms/Memoir/ScreenShot.tsx 正常にrenderすること 
     >
       <Memo(Header)
         endDate="2020-01-07"
+        isTitle={true}
         startDate="2020-01-01"
       />
       <RenderItem

--- a/src/components/organisms/Memoir/stories.tsx
+++ b/src/components/organisms/Memoir/stories.tsx
@@ -27,6 +27,8 @@ const props = (): Props => ({
       image: 'https://placehold.jp/150x150.png',
     },
   ],
+  selectedUserIDList: ['test'],
+  onChangeUserID: mockFn('onChangeUserID'),
 });
 
 const screenShotProps = (): ScreenShotProps => ({

--- a/src/components/pages/Memoir/Connected.tsx
+++ b/src/components/pages/Memoir/Connected.tsx
@@ -30,6 +30,7 @@ export type ConnectedType = {
   endDate: string;
   users: User[];
   selectedUserIDList: string[];
+  isFilter: boolean;
   onItem: () => void;
   onScreenShot: () => void;
   onLoadMore: (after: string | null) => void;
@@ -42,6 +43,7 @@ const initialState = () => ({
 
 const Connected: React.FC<Props> = (props) => {
   const [state, setState] = useState<State>(initialState());
+  const [isFilter, setIsFilter] = useState<boolean>(false);
   const user = useRecoilValue(userState);
   const navigation = useNavigation();
 
@@ -82,19 +84,13 @@ const Connected: React.FC<Props> = (props) => {
 
   const onChangeUserID = useCallback(
     (userIDList: string[]) => {
+      setIsFilter(true);
       reset();
 
       setState((s) => ({ ...s, userIDList }));
     },
     [reset]
   );
-
-  const onScreenShot = useCallback(() => {
-    navigation.navigate('MemoirScreenShot', {
-      startDate: props.startDate,
-      endDate: props.endDate,
-    });
-  }, [props, navigation]);
 
   const users: User[] = [
     { id: user.userID || '', displayName: user.displayName, image: user.image },
@@ -108,14 +104,24 @@ const Connected: React.FC<Props> = (props) => {
   }));
 
   const tUsers = [...users, ...relationshipUsers];
+  const selectedUserIDList = state.userIDList || tUsers.map((v) => v.id);
+
+  const onScreenShot = useCallback(() => {
+    navigation.navigate('MemoirScreenShot', {
+      startDate: props.startDate,
+      endDate: props.endDate,
+      selectedUserIDList,
+    });
+  }, [props, navigation, selectedUserIDList]);
 
   return (
     <Plain
       startDate={props.startDate}
       endDate={props.endDate}
+      isFilter={isFilter}
       items={items}
       users={tUsers}
-      selectedUserIDList={state.userIDList || tUsers.map((v) => v.id)}
+      selectedUserIDList={selectedUserIDList}
       pageInfo={pageInfo}
       onLoadMore={onLoadMore}
       loading={queryResult.loading}

--- a/src/components/pages/Memoir/Connected.tsx
+++ b/src/components/pages/Memoir/Connected.tsx
@@ -16,6 +16,7 @@ type Props = {
 
 type State = {
   after: string | null;
+  userIDList?: string[];
 };
 
 type User = {
@@ -28,9 +29,11 @@ export type ConnectedType = {
   startDate: string;
   endDate: string;
   users: User[];
+  selectedUserIDList: string[];
   onItem: () => void;
   onScreenShot: () => void;
   onLoadMore: (after: string | null) => void;
+  onChangeUserID: (userIDList: string[]) => void;
 };
 
 const initialState = () => ({
@@ -59,11 +62,12 @@ const Connected: React.FC<Props> = (props) => {
         endDate: props.endDate,
         first: 8,
         after: state.after,
+        userIDList: state.userIDList,
       },
     },
   });
 
-  const { items, pageInfo } = useItemsInPeriodPaging(queryResult, {
+  const { items, pageInfo, reset } = useItemsInPeriodPaging(queryResult, {
     merge: true,
   });
 
@@ -75,6 +79,15 @@ const Connected: React.FC<Props> = (props) => {
   }, []);
 
   const onItem = useCallback(() => {}, []);
+
+  const onChangeUserID = useCallback(
+    (userIDList: string[]) => {
+      reset();
+
+      setState((s) => ({ ...s, userIDList }));
+    },
+    [reset]
+  );
 
   const onScreenShot = useCallback(() => {
     navigation.navigate('MemoirScreenShot', {
@@ -94,18 +107,22 @@ const Connected: React.FC<Props> = (props) => {
     image: v?.node?.user?.image || '',
   }));
 
+  const tUsers = [...users, ...relationshipUsers];
+
   return (
     <Plain
       startDate={props.startDate}
       endDate={props.endDate}
       items={items}
-      users={[...users, ...relationshipUsers]}
+      users={tUsers}
+      selectedUserIDList={state.userIDList || tUsers.map((v) => v.id)}
       pageInfo={pageInfo}
       onLoadMore={onLoadMore}
       loading={queryResult.loading}
       error={queryResult.error}
       onItem={onItem}
       onScreenShot={onScreenShot}
+      onChangeUserID={onChangeUserID}
     />
   );
 };

--- a/src/components/pages/Memoir/Plain.tsx
+++ b/src/components/pages/Memoir/Plain.tsx
@@ -27,9 +27,11 @@ const Plain: React.FC<Props> = (props) => {
       onItem={props.onItem}
       items={props.items}
       users={props.users}
+      selectedUserIDList={props.selectedUserIDList}
       onLoadMore={props.onLoadMore}
       pageInfo={props.pageInfo}
       onScreenShot={props.onScreenShot}
+      onChangeUserID={props.onChangeUserID}
     />
   );
 };

--- a/src/components/pages/Memoir/Plain.tsx
+++ b/src/components/pages/Memoir/Plain.tsx
@@ -15,7 +15,7 @@ export type Props = QueryProps &
 
 const Plain: React.FC<Props> = (props) => {
   if (props.error) return <ErrorPage error={props.error} />;
-  if (props.loading && props.items.length === 0) {
+  if (props.loading && props.items.length === 0 && !props.isFilter) {
     return null;
   }
 

--- a/src/components/pages/Memoir/ScreenShot/Connected.tsx
+++ b/src/components/pages/Memoir/ScreenShot/Connected.tsx
@@ -11,9 +11,10 @@ import Plain from './Plain';
 export type Props = {
   startDate: string;
   endDate: string;
+  selectedUserIDList: string[];
 };
 
-export type ConnectedType = Props & {
+export type ConnectedType = Omit<Props, 'selectedUserIDList'> & {
   users: User[];
 };
 
@@ -39,6 +40,7 @@ const Connected: React.FC<Props> = (props) => {
       input: {
         startDate: props.startDate,
         endDate: props.endDate,
+        userIDList: props.selectedUserIDList,
         first: 200,
         after: '',
       },

--- a/src/components/pages/Memoir/ScreenShot/__tests__/Connected.test.tsx
+++ b/src/components/pages/Memoir/ScreenShot/__tests__/Connected.test.tsx
@@ -8,6 +8,7 @@ import Connected, { Props } from '../Connected';
 const propsData = (): Props => ({
   startDate: '2020-01-01',
   endDate: '2020-01-07',
+  selectedUserIDList: ['1'],
 });
 
 describe('components/pages/Memoir/ScreenShot/Connected.tsx', () => {

--- a/src/components/pages/Memoir/ScreenShot/index.tsx
+++ b/src/components/pages/Memoir/ScreenShot/index.tsx
@@ -16,9 +16,15 @@ export type Props = {
 };
 
 const MemoirScreenShot: React.FC<Props> = (props) => {
-  const { startDate, endDate } = props.route.params;
+  const { startDate, endDate, selectedUserIDList } = props.route.params;
 
-  return <Connected startDate={startDate} endDate={endDate} />;
+  return (
+    <Connected
+      startDate={startDate}
+      endDate={endDate}
+      selectedUserIDList={selectedUserIDList}
+    />
+  );
 };
 
 export default memo(MemoirScreenShot);

--- a/src/components/templates/Memoir/Page.tsx
+++ b/src/components/templates/Memoir/Page.tsx
@@ -19,7 +19,9 @@ export type Props = Pick<
   | 'onItem'
   | 'pageInfo'
   | 'users'
+  | 'selectedUserIDList'
   | 'onScreenShot'
+  | 'onChangeUserID'
 > & {
   startDate: string;
   endDate: string;
@@ -45,6 +47,8 @@ const Page: React.FC<Props> = (props) => {
             onItem={props.onItem}
             onLoadMore={props.onLoadMore}
             users={props.users}
+            selectedUserIDList={props.selectedUserIDList}
+            onChangeUserID={props.onChangeUserID}
           />
         </View>
         <View style={styles.action}>

--- a/src/components/templates/Memoir/stories.tsx
+++ b/src/components/templates/Memoir/stories.tsx
@@ -22,7 +22,32 @@ const props = (): Props => ({
       image: 'https://placehold.jp/150x150.png',
     },
   ],
+  selectedUserIDList: ['test'],
+  onChangeUserID: mockFn('onChangeUserID'),
   onScreenShot: mockFn('onScreenShot'),
 });
 
-storiesOf('templates/Memoir', module).add('Page', () => <Page {...props()} />);
+storiesOf('templates/Memoir/Page', module)
+  .add('ユーザー:1人', () => <Page {...props()} />)
+  .add('ユーザー:複数', () => (
+    <Page
+      {...props()}
+      users={[
+        {
+          id: 'test',
+          displayName: 'suzuki',
+          image: 'https://placehold.jp/150x150.png',
+        },
+        {
+          id: 'test2',
+          displayName: 'suzuki',
+          image: 'https://placehold.jp/250x250.png',
+        },
+        {
+          id: 'test3',
+          displayName: 'suzuki',
+          image: 'https://placehold.jp/350x350.png',
+        },
+      ]}
+    />
+  ));

--- a/src/hooks/useUser.tsx
+++ b/src/hooks/useUser.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useCallback, useState } from 'react';
-import { useRecoilValueLoadable, useRecoilState } from 'recoil';
+import { useRecoilValueLoadable, useRecoilState, useRecoilValue } from 'recoil';
 import { existUserID } from 'store/selectors';
 import 'react-native-get-random-values';
 import { v4 as uuidv4 } from 'uuid';
-import { userState } from 'store/atoms';
+import { userState, authUserState } from 'store/atoms';
 import { useCreateUserMutation, useUserLazyQuery } from 'queries/api/index';
 import { storageKey, setItem } from 'lib/storage';
 import usePrevious from 'hooks/usePrevious';
@@ -12,6 +12,7 @@ const useUser = () => {
   const [loading, setLoading] = useState(true);
   const [user, setUser] = useRecoilState(userState);
   const userID = useRecoilValueLoadable(existUserID);
+  const authUser = useRecoilValue(authUserState);
   const [getUser, userUserQuery] = useUserLazyQuery();
   const prevUserUserQueryLoading = usePrevious(userUserQuery.loading);
 
@@ -36,13 +37,13 @@ const useUser = () => {
   }, [createUserMutation]);
 
   const setup = useCallback(() => {
-    if (!user.id && !userID.contents) {
+    if (!user.id && !userID.contents && !authUser.uid) {
       setLoading(false);
       return;
     }
 
     getUser();
-  }, [user.id, getUser, userID.contents]);
+  }, [user.id, getUser, userID.contents, authUser.uid]);
 
   useEffect(() => {
     if (userID.state === 'hasValue') {

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -24,5 +24,6 @@ export type RootStackParamList = {
   MemoirScreenShot: {
     startDate: string;
     endDate: string;
+    selectedUserIDList: string[];
   };
 };


### PR DESCRIPTION
## 関連 issue

- fixes #107 

## 対応内容

<img src=https://user-images.githubusercontent.com/19209314/132232168-ee9695da-7b61-4bf3-94b5-d523e703b1dc.png  width=200>

 - memoirする画面にユーザーのフィルター機能を追加
 - 共有するにもユーザーのフィルターを反映する機能を追加

## 開発用メモ
無し

