### PR TITLE
GraphQLのextensionsでエラーハンドリングを追加

### DIFF
--- a/src/components/templates/Search/__tests__/__snapshots__/Page.test.tsx.snap
+++ b/src/components/templates/Search/__tests__/__snapshots__/Page.test.tsx.snap
@@ -31,11 +31,11 @@ exports[`components/templates/Search/Page.tsx 正常にrenderすること 1`] = 
         </Text>
       </View>
       <Memo(InputDate)
-        endDate={2022-01-27T15:00:00.000Z}
+        endDate={2022-02-25T15:00:00.000Z}
         error={false}
         onChangeEndDate={[Function]}
         onChangeStartDate={[Function]}
-        startDate={2022-01-21T15:00:00.000Z}
+        startDate={2022-02-19T15:00:00.000Z}
       />
       <View
         pb={2}

--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -1,0 +1,20 @@
+const CodeDefault = '-1' as const;
+// バリデーションエラー
+const CodeValidation = '000001' as const;
+// 無効な認証
+const CodeInvalidAuthorization = '000002' as const;
+// Not Found
+const CodeNotFound = '000003' as const;
+// Already Exists
+const CodeAlreadyExists = '000004' as const;
+// 自身の招待コード
+const CodeMyInviteCode = '000005' as const;
+
+export const errorCode = {
+  CodeDefault,
+  CodeValidation,
+  CodeInvalidAuthorization,
+  CodeNotFound,
+  CodeAlreadyExists,
+  CodeMyInviteCode,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -7332,15 +7332,10 @@ can-use-dom@^0.1.0:
   resolved "https://registry.yarnpkg.com/can-use-dom/-/can-use-dom-0.1.0.tgz#22cc4a34a0abc43950f42c6411024a3f6366b45a"
   integrity sha1-IsxKNKCrxDlQ9CxkEQJKP2NmtFo=
 
-caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001248:
-  version "1.0.30001251"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz#6853a606ec50893115db660f82c094d18f096d85"
-  integrity sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==
-
-caniuse-lite@^1.0.30001271:
-  version "1.0.30001274"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001274.tgz#26ca36204d15b17601ba6fc35dbdad950a647cc7"
-  integrity sha512-+Nkvv0fHyhISkiMIjnyjmf5YJcQ1IQHZN6U9TLUMroWR38FNwpsC51Gb68yueafX1V6ifOisInSgP9WJFS13ew==
+caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001248, caniuse-lite@^1.0.30001271:
+  version "1.0.30001312"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz"
+  integrity sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==
 
 capital-case@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
## 関連 issue

- fixes #147 

## 対応内容

<img src=https://user-images.githubusercontent.com/19209314/155846533-4f6aa23c-a9d9-4f99-a6a3-476bf75cacb5.png  width=200>

 - GraphQLのextensionsのエラーハンドリングを追加



## 開発用メモ
無し

