### PR TITLE
今週のmemoirを確認するをタッチした時に最新の情報を取得しなおす

### DIFF
--- a/src/components/organisms/MyPage/Authenticated.tsx
+++ b/src/components/organisms/MyPage/Authenticated.tsx
@@ -31,7 +31,9 @@ const Authenticated: React.FC<Props> = (props) => {
     <View style={styles.root}>
       <View style={styles.user}>
         <View mt={4}>
-          <UserImage image={props.user.image} />
+          <TouchableOpacity onPress={props.onUpdateProfile}>
+            <UserImage image={props.user.image} />
+          </TouchableOpacity>
         </View>
         <View m={4}>
           <TouchableOpacity onPress={props.onUpdateProfile}>

--- a/src/components/organisms/MyPage/NotAuthenticated.tsx
+++ b/src/components/organisms/MyPage/NotAuthenticated.tsx
@@ -19,7 +19,9 @@ const NotAuthenticated: React.FC<Props> = (props) => {
     <View style={styles.root}>
       <View style={styles.user}>
         <View mt={4}>
-          <UserImage image={props.user.image} />
+          <TouchableOpacity onPress={props.onUpdateProfile}>
+            <UserImage image={props.user.image} />
+          </TouchableOpacity>
         </View>
         <View m={4}>
           <TouchableOpacity onPress={props.onUpdateProfile}>

--- a/src/components/organisms/MyPage/__tests__/__snapshots__/Authenticated.test.tsx.snap
+++ b/src/components/organisms/MyPage/__tests__/__snapshots__/Authenticated.test.tsx.snap
@@ -20,9 +20,13 @@ exports[`components/organisms/MyPage/Authenticated.tsx 正常にrenderするこ�
     <View
       mt={4}
     >
-      <Memo(UserImage)
-        image=""
-      />
+      <ForwardRef
+        onPress={[MockFunction]}
+      >
+        <Memo(UserImage)
+          image=""
+        />
+      </ForwardRef>
     </View>
     <View
       m={4}

--- a/src/components/organisms/MyPage/__tests__/__snapshots__/NotAuthenticated.test.tsx.snap
+++ b/src/components/organisms/MyPage/__tests__/__snapshots__/NotAuthenticated.test.tsx.snap
@@ -21,9 +21,13 @@ exports[`components/organisms/MyPage/NotAuthenticated.tsx 正常にrenderする�
     <View
       mt={4}
     >
-      <Memo(UserImage)
-        image=""
-      />
+      <ForwardRef
+        onPress={[MockFunction]}
+      >
+        <Memo(UserImage)
+          image=""
+        />
+      </ForwardRef>
     </View>
     <View
       m={4}

--- a/src/components/organisms/Search/Input/InputUsers.tsx
+++ b/src/components/organisms/Search/Input/InputUsers.tsx
@@ -1,5 +1,5 @@
 import React, { memo } from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, ViewStyle } from 'react-native';
 import View from 'components/atoms/View';
 import { User } from 'queries/api/index';
 import UserButton, {
@@ -12,8 +12,14 @@ export type Props = {
 } & Pick<UserButtonProps, 'onAdd' | 'onRemove'>;
 
 const InputUsers: React.FC<Props> = (props) => {
+  const style: ViewStyle[] = [styles.users];
+
+  if (props.userIDList.length > 1) {
+    style.push(styles.userMulti);
+  }
+
   return (
-    <View style={styles.users}>
+    <View style={style}>
       {props.users.map((v) => (
         <View px={3} key={v.id}>
           <UserButton
@@ -31,11 +37,13 @@ const InputUsers: React.FC<Props> = (props) => {
 
 const styles = StyleSheet.create({
   users: {
-    justifyContent: 'center',
     flexWrap: 'wrap',
     alignItems: 'center',
     flexDirection: 'row',
     width: '80%',
+  },
+  userMulti: {
+    justifyContent: 'center',
   },
 });
 

--- a/src/components/organisms/Search/Input/__tests__/__snapshots__/InputUsers.test.tsx.snap
+++ b/src/components/organisms/Search/Input/__tests__/__snapshots__/InputUsers.test.tsx.snap
@@ -3,13 +3,14 @@
 exports[`components/organisms/Search/Input/InputUsers.tsx 正常にrenderすること 1`] = `
 <View
   style={
-    Object {
-      "alignItems": "center",
-      "flexDirection": "row",
-      "flexWrap": "wrap",
-      "justifyContent": "center",
-      "width": "80%",
-    }
+    Array [
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "flexWrap": "wrap",
+        "width": "80%",
+      },
+    ]
   }
 >
   <View

--- a/src/components/pages/Memoir/Connected.tsx
+++ b/src/components/pages/Memoir/Connected.tsx
@@ -80,6 +80,7 @@ const Connected: React.FC<Props> = (props) => {
     variables: {
       input,
     },
+    fetchPolicy: 'network-only',
   });
 
   const { items, pageInfo, reset } = useItemsInPeriodPaging(queryResult, {


### PR DESCRIPTION
## 関連 issue

- fixes #115 

## 対応内容

 - 一度memoir画面を開いた後に、達成したタスク追加→memoir画面を開いた際に表示を更新するように修正

## 開発用メモ
無し

