### PR TITLE
招待コード入力画面でキーボードのdoneをタップする、キーボードが再度出現して閉じることができない

### DIFF
--- a/src/components/molecules/InputCode/InputCode.tsx
+++ b/src/components/molecules/InputCode/InputCode.tsx
@@ -29,17 +29,19 @@ const InputCode: React.FC<Props> = (props) => {
   const textInputRef = useRef<TextInput>(null);
   const timeout = useRef<number | null>(null);
 
-  useFocusEffect(() => {
-    timeout.current = Number(
-      setTimeout(() => textInputRef.current?.focus(), 300)
-    );
+  useFocusEffect(
+    useCallback(() => {
+      timeout.current = Number(
+        setTimeout(() => textInputRef.current?.focus(), 300)
+      );
 
-    return () => {
-      if (timeout.current) {
-        clearTimeout(timeout.current);
-      }
-    };
-  });
+      return () => {
+        if (timeout.current) {
+          clearTimeout(timeout.current);
+        }
+      };
+    }, [])
+  );
 
   const handlePress = useCallback(() => {
     textInputRef?.current?.focus();

--- a/src/components/organisms/AddShareUser/InviteCard.tsx
+++ b/src/components/organisms/AddShareUser/InviteCard.tsx
@@ -59,7 +59,7 @@ const InviteCard: React.FC<Props> = (props) => {
           <View style={styles.user}>
             <UserImage image={props.user.image} size={80} />
             <View py={3}>
-              <Text size="sm">{props.user.displayName}</Text>
+              <Text size="sm">{props.user.displayName || '未設定'}</Text>
             </View>
           </View>
           {props.invite.code === '' ? (

--- a/src/components/pages/MyPage/Connected.tsx
+++ b/src/components/pages/MyPage/Connected.tsx
@@ -52,6 +52,7 @@ const Connected: React.FC<Props> = () => {
   useFocusEffect(
     useCallback(() => {
       if (authUser.uid) {
+        userQuery?.refetch?.();
         getRelationshipRequests({
           variables: {
             input: {
@@ -71,7 +72,7 @@ const Connected: React.FC<Props> = () => {
           },
         });
       }
-    }, [authUser.uid, getRelationshipRequests, getRelationships])
+    }, [authUser.uid, getRelationshipRequests, getRelationships, userQuery])
   );
 
   const onLogin = useCallback(() => {

--- a/src/components/pages/Setting/AddShareUser/index.tsx
+++ b/src/components/pages/Setting/AddShareUser/index.tsx
@@ -5,7 +5,7 @@ import { StackNavigationProp } from '@react-navigation/stack';
 import useSentryBreadcrumb from 'hooks/useSentryBreadcrumb';
 import Connected from './Connected';
 
-type ScreenNavigationProp = StackNavigationProp<
+export type ScreenNavigationProp = StackNavigationProp<
   RootStackParamList,
   'SettingAddShareUser'
 >;

--- a/src/components/templates/UpdateProfile/Page.tsx
+++ b/src/components/templates/UpdateProfile/Page.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useState } from 'react';
+import React, { memo, useState, useCallback } from 'react';
 import { StyleSheet } from 'react-native';
 import { ConnectedType } from 'components/pages/UpdateProfile/Connected';
 import ProfileImage from 'components/organisms/UpdateProfile/ProfileImage';
@@ -28,6 +28,18 @@ const initialState = (user: User) => ({
 const Page: React.FC<Props> = (props) => {
   const [state, setState] = useState<State>(initialState(props.user));
 
+  const disabledButton = useCallback(() => {
+    if (state.displayName.length === 0) {
+      return true;
+    }
+
+    if (state.displayName.length > 20) {
+      return true;
+    }
+
+    return false;
+  }, [state.displayName]);
+
   return (
     <View style={styles.root}>
       <FocusAwareStatusBar
@@ -48,10 +60,11 @@ const Page: React.FC<Props> = (props) => {
           returnKeyType="done"
           defaultValue={state.displayName}
           style={styles.input}
+          maxLength={15}
         />
         <View my={3}>
           <Text textAlign="center" size="sm">
-            表示名を入力したください
+            表示名を入力してください
           </Text>
         </View>
       </View>
@@ -60,7 +73,7 @@ const Page: React.FC<Props> = (props) => {
           title="保存"
           size="lg"
           width={200}
-          disabled={props.loading}
+          disabled={props.loading || disabledButton()}
           loading={props.loading}
           onPress={() => props.onSave(state)}
         />

--- a/src/components/templates/UpdateProfile/__tests__/__snapshots__/Page.test.tsx.snap
+++ b/src/components/templates/UpdateProfile/__tests__/__snapshots__/Page.test.tsx.snap
@@ -30,6 +30,7 @@ exports[`components/templates/UpdateProfile/Page.tsx 正常にrenderすること
   >
     <TextInput
       defaultValue="test-name"
+      maxLength={15}
       onChangeText={[Function]}
       placeholder="表示名"
       returnKeyType="done"
@@ -49,7 +50,7 @@ exports[`components/templates/UpdateProfile/Page.tsx 正常にrenderすること
         textAlign="center"
         variants="body"
       >
-        表示名を入力したください
+        表示名を入力してください
       </Text>
     </View>
   </View>

--- a/src/queries/createAuthUser.gql
+++ b/src/queries/createAuthUser.gql
@@ -2,5 +2,6 @@ mutation CreateAuthUser($input: NewAuthUser!) {
   createAuthUser(input: $input) {
     id
     new
+    displayName
   }
 }


### PR DESCRIPTION
## 関連 issue

- fixes
  - #183 
  - #184 

## 対応内容
 - 招待コード入力画面でキーボードのdoneをタップする、キーボードが再度出現して閉じることができないバグ修正
 - ユーザー名を未設定にできないように修正

## 開発用メモ
無し

