### PR TITLE
Androidのボタンのローディング表示を修正

### DIFF
--- a/src/components/atoms/Button/Button.tsx
+++ b/src/components/atoms/Button/Button.tsx
@@ -40,7 +40,10 @@ const Button: React.FC<Props> = (props) => {
   if (props.loading) {
     return (
       <View style={[styles.disabledButton, buttonStyle]}>
-        <ActivityIndicator size={configSize.loadingSize} />
+        <ActivityIndicator
+          size={configSize.loadingSize}
+          color={theme().color.base.light}
+        />
       </View>
     );
   }

--- a/src/components/organisms/Cards/Cards.tsx
+++ b/src/components/organisms/Cards/Cards.tsx
@@ -25,7 +25,7 @@ const Cards: React.FC<Props> = (props) => {
 
       {props.addItemLoading && (
         <View style={styles.loading} mb={3} mx={3}>
-          <ActivityIndicator size="large" />
+          <ActivityIndicator size="large" color={theme().color.base.light} />
         </View>
       )}
 

--- a/src/components/organisms/RelationshipRequest/Card.tsx
+++ b/src/components/organisms/RelationshipRequest/Card.tsx
@@ -51,7 +51,7 @@ const Card: React.FC<Props> = (props) => {
           <View style={styles.buttonWrap}>
             {props.acceptRequesting ? (
               <View style={styles.applyButton}>
-                <ActivityIndicator />
+                <ActivityIndicator color={theme().color.base.light} />
               </View>
             ) : (
               <TouchableOpacity onPress={props.onOK}>
@@ -62,7 +62,7 @@ const Card: React.FC<Props> = (props) => {
             )}
             {props.ngRequesting ? (
               <View style={styles.removeButton}>
-                <ActivityIndicator />
+                <ActivityIndicator color={theme().color.base.light} />
               </View>
             ) : (
               <TouchableOpacity onPress={props.onNG}>


### PR DESCRIPTION
## 関連 issue

- fixes #191 

## 対応内容

<img src=https://user-images.githubusercontent.com/19209314/166184654-28cb803b-61ce-4979-bcb8-91a9334457ea.png  width=200>
  - Androidでボタンのローディングが表示されていないので修正

## 開発用メモ
無し

