### PR TITLE
iPhoneSE2で共有ボタンが見切れる

### DIFF
--- a/src/components/templates/Memoir/Page.tsx
+++ b/src/components/templates/Memoir/Page.tsx
@@ -10,6 +10,7 @@ import ShareButton from 'components/molecules/Memoir/ShareButton';
 import { Props as PlainProps } from 'components/pages/Memoir/Plain';
 import IconButton from 'components/molecules/IconButton';
 import FocusAwareStatusBar from 'components/organisms/FocusAwareStatusBar';
+import { iosSelector } from 'lib/responsive';
 
 export type Props = Pick<
   PlainProps,
@@ -80,7 +81,7 @@ const styles = StyleSheet.create({
     height: '100%',
   },
   action: {
-    bottom: 0,
+    bottom: iosSelector({ iPhone8: 30, other: 0 }),
     height: Platform.OS === 'ios' ? 22 : 55,
     position: 'absolute',
   },

--- a/src/lib/responsive.ts
+++ b/src/lib/responsive.ts
@@ -1,0 +1,25 @@
+import { Dimensions, PixelRatio } from 'react-native';
+
+const DEVICES = {
+  iPhoneSe: { width: 640 },
+  iPhone8: { width: 750 },
+};
+
+const fetchDeviceWidth = () =>
+  Dimensions.get('window').width * PixelRatio.get();
+
+export const devices = ['iPhoneSE', 'iPhone8', 'other'] as const;
+
+export type IosSelectorProps = {
+  [k in typeof devices[number]]?: any;
+};
+export type IosSelectors = keyof IosSelectorProps;
+
+const iosSelector = ({ iPhoneSE, iPhone8, other }: IosSelectorProps) => {
+  if (iPhoneSE && DEVICES.iPhoneSe.width >= fetchDeviceWidth()) return iPhoneSE;
+  if (iPhone8 && DEVICES.iPhone8.width >= fetchDeviceWidth()) return iPhone8;
+
+  return other;
+};
+
+export { iosSelector };


### PR DESCRIPTION
## 関連 issue

- fixes #197 

## 対応内容

<img src=https://user-images.githubusercontent.com/19209314/167232208-87f0dca2-32bd-4287-9302-52e320febee7.png  width=200>
  - iPhonSE2とiPhone8で共有ボタンのレイアウトが崩れているので修正

## 開発用メモ
無し

