### PR TITLE
今週のmemoirを確認するでページング後にユーザー選択をすると、日付がおかしくなる

### DIFF
--- a/src/components/pages/Home/Connected.tsx
+++ b/src/components/pages/Home/Connected.tsx
@@ -96,7 +96,7 @@ const Connected: React.FC<Props> = (props) => {
 
   const onMemoir = useCallback(() => {
     navigation.navigate('Memoir', {
-      startDate: dayjs().add(-6, 'day').format('YYYY-MM-DDT00:00:00+09:00'),
+      startDate: dayjs().add(-100, 'day').format('YYYY-MM-DDT00:00:00+09:00'),
       endDate: dayjs().format('YYYY-MM-DDT00:00:00+09:00'),
     });
   }, [navigation]);

--- a/src/components/pages/Home/Connected.tsx
+++ b/src/components/pages/Home/Connected.tsx
@@ -96,7 +96,7 @@ const Connected: React.FC<Props> = (props) => {
 
   const onMemoir = useCallback(() => {
     navigation.navigate('Memoir', {
-      startDate: dayjs().add(-100, 'day').format('YYYY-MM-DDT00:00:00+09:00'),
+      startDate: dayjs().add(-6, 'day').format('YYYY-MM-DDT00:00:00+09:00'),
       endDate: dayjs().format('YYYY-MM-DDT00:00:00+09:00'),
     });
   }, [navigation]);

--- a/src/components/pages/Memoir/Connected.tsx
+++ b/src/components/pages/Memoir/Connected.tsx
@@ -101,7 +101,11 @@ const Connected: React.FC<Props> = (props) => {
       setIsFilter(true);
       reset();
 
-      setState((s) => ({ ...s, userIDList }));
+      setState((s) => ({
+        ...s,
+        userIDList,
+        after: '',
+      }));
     },
     [reset]
   );


### PR DESCRIPTION
## 関連 issue

- fixes #{issue 番号}

## 対応内容

 - 今週のmemoirを確認するでページング後にユーザー選択をすると、日付がおかしくなる不具合の修正

## 開発用メモ
無し

