### PR TITLE
AndroidのGoogleアカウントのログインでループする

### DIFF
--- a/src/components/molecules/Overlay/Loading.tsx
+++ b/src/components/molecules/Overlay/Loading.tsx
@@ -23,7 +23,7 @@ const Loading: React.FC<Props> = (props) => {
     return () => clearInterval(interval);
   }, [count]);
 
-  const style = { paddingLeft: width / 2 - 50 };
+  const style = { paddingLeft: width / 2 - (props.text?.length || 0) * 14 };
 
   return (
     <View style={styles.root}>
@@ -32,7 +32,11 @@ const Loading: React.FC<Props> = (props) => {
           <ActivityIndicator color={theme().color.base.light} />
         </View>
         <View ml={2}>
-          <Text color="baseLight" fontFamily="NotoSansJP-Bold">
+          <Text
+            color="baseLight"
+            fontFamily="NotoSansJP-Bold"
+            textAlign="center"
+          >
             {props.text}{' '}
             {(() => {
               if (count % 3 === 0) {

--- a/src/components/molecules/Overlay/__tests__/__snapshots__/Loading.test.tsx.snap
+++ b/src/components/molecules/Overlay/__tests__/__snapshots__/Loading.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`components/molecules/Overlay/Loading.tsx 正常にrenderすること 1`
           "flexDirection": "row",
         },
         Object {
-          "paddingLeft": 325,
+          "paddingLeft": 333,
         },
       ]
     }
@@ -40,6 +40,7 @@ exports[`components/molecules/Overlay/Loading.tsx 正常にrenderすること 1`
       <Text
         color="baseLight"
         fontFamily="NotoSansJP-Bold"
+        textAlign="center"
         variants="body"
       >
         テスト

--- a/src/components/organisms/Home/NotFound.tsx
+++ b/src/components/organisms/Home/NotFound.tsx
@@ -13,7 +13,7 @@ const NotFound: React.FC<Props> = (props) => {
   return (
     <View style={styles.root}>
       <View>
-        <Text color="baseDark">
+        <Text color="baseDark" textAlign="center">
           {dayjs(props.date).isSame(dayjs(), 'day') ? '今日' : 'この日'}
           のタスクは
           {'\n'}まだありません

--- a/src/components/organisms/Memoir/ScreenShot.ios.tsx
+++ b/src/components/organisms/Memoir/ScreenShot.ios.tsx
@@ -277,7 +277,7 @@ const ScreenShot: React.FC<Props> = (props) => {
           );
         })}
       </ScrollView>
-      {!loading && <Loading text="作成中" />}
+      {loading && <Loading text="作成中" />}
     </>
   );
 };

--- a/src/components/organisms/Memoir/__tests__/__snapshots__/ScreenShot.test.tsx.snap
+++ b/src/components/organisms/Memoir/__tests__/__snapshots__/ScreenShot.test.tsx.snap
@@ -156,5 +156,8 @@ exports[`components/organisms/Memoir/ScreenShot.tsx 正常にrenderすること 
       </View>
     </ViewShot>
   </ScrollView>
+  <Memo(Loading)
+    text="作成中"
+  />
 </Fragment>
 `;

--- a/src/components/pages/Login/Connected.tsx
+++ b/src/components/pages/Login/Connected.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useEffect, useCallback } from 'react';
+import React, { memo, useEffect, useCallback, useState } from 'react';
 import { Alert } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { storageKey, getItem } from 'lib/storage';
@@ -16,8 +16,13 @@ import { useNotification } from 'containers/Notification';
 type Props = {};
 
 const Connected: React.FC<Props> = () => {
-  const { setupAuth, onAppleLogin, onGoogleLogin, onLogout } =
-    useFirebaseAuth(true);
+  const [loading, setLoading] = useState(false);
+  const { setupAuth, onAppleLogin, onGoogleLogin, onLogout } = useFirebaseAuth(
+    true,
+    () => {
+      setLoading(false);
+    }
+  );
   const { refetch } = useHomeItems();
   const { onPermissionRequest } = useNotification();
   const authUser = useRecoilValue(authUserState);
@@ -61,7 +66,17 @@ const Connected: React.FC<Props> = () => {
   }
 
   return (
-    <TemplateLogin onAppleLogin={onAppleLogin} onGoogleLogin={onGoogleLogin} />
+    <TemplateLogin
+      loading={loading}
+      onAppleLogin={async () => {
+        setLoading(true);
+        onAppleLogin();
+      }}
+      onGoogleLogin={() => {
+        setLoading(true);
+        onGoogleLogin();
+      }}
+    />
   );
 };
 

--- a/src/components/pages/Top/Connected.tsx
+++ b/src/components/pages/Top/Connected.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback } from 'react';
+import React, { memo, useCallback, useState } from 'react';
 import { Platform } from 'react-native';
 import useFirebaseAuth from 'hooks/useFirebaseAuth';
 import { useSetRecoilState } from 'recoil';
@@ -15,21 +15,28 @@ export type Props = {
 };
 
 export type ConnectedType = {
+  loading: boolean;
   onSkip: () => void;
   onLogin: () => void;
 };
 
 const Connected: React.FC<Props> = (props) => {
   const setHomeState = useSetRecoilState(homeState);
+  const [loading, setLoading] = useState(false);
 
   const { setupAuth, onAppleLogin, onGoogleLogin } = useFirebaseAuth(
     false,
-    () => props.setCreate(false)
+    () => {
+      setLoading(false);
+      props.setCreate(false);
+    }
   );
 
   const setHomeItemsState = useSetRecoilState(homeItemsState);
 
   const onLogin = useCallback(() => {
+    setLoading(true);
+
     if (Platform.OS === 'ios') {
       onAppleLogin();
     } else {
@@ -60,13 +67,16 @@ const Connected: React.FC<Props> = (props) => {
 
   return (
     <TemplateTop
+      loading={loading}
       onLogin={onLogin}
       onAppleLogin={async () => {
         props.setCreate(true);
+        setLoading(true);
         await onAppleLogin();
       }}
       onGoogleLogin={async () => {
         props.setCreate(true);
+        setLoading(true);
         await onGoogleLogin();
       }}
       onSkip={onSkip}

--- a/src/components/templates/Login/Page.tsx
+++ b/src/components/templates/Login/Page.tsx
@@ -6,26 +6,31 @@ import Text from 'components/atoms/Text';
 import Divider from 'components/atoms/Divider';
 import { UseFirebaseAuth } from 'hooks/useFirebaseAuth';
 import Form from 'components/organisms/Login/Form';
+import Loading from 'components/molecules/Overlay/Loading';
 
 export type Props = {
+  loading: boolean;
   onAppleLogin: UseFirebaseAuth['onAppleLogin'];
   onGoogleLogin: UseFirebaseAuth['onGoogleLogin'];
 };
 
 const Page: React.FC<Props> = (props) => {
   return (
-    <View style={styles.root}>
-      <View>
-        <Text size="xl">🎊 Memoirへようこそ </Text>
+    <>
+      <View style={styles.root}>
+        <View>
+          <Text size="xl">🎊 Memoirへようこそ </Text>
+        </View>
+        <View style={styles.divider}>
+          <Divider mt={2} mb={5} />
+        </View>
+        <Form
+          onAppleLogin={props.onAppleLogin}
+          onGoogleLogin={props.onGoogleLogin}
+        />
       </View>
-      <View style={styles.divider}>
-        <Divider mt={2} mb={5} />
-      </View>
-      <Form
-        onAppleLogin={props.onAppleLogin}
-        onGoogleLogin={props.onGoogleLogin}
-      />
-    </View>
+      {props.loading && <Loading text="ログイン中" />}
+    </>
   );
 };
 

--- a/src/components/templates/Login/stories.tsx
+++ b/src/components/templates/Login/stories.tsx
@@ -4,6 +4,7 @@ import { mockFn } from 'storyBookUtils/index';
 import Page, { Props } from './Page';
 
 const props = (): Props => ({
+  loading: false,
   onAppleLogin: mockFn('onAppleLogin'),
   onGoogleLogin: mockFn('onGoogleLogin'),
 });

--- a/src/components/templates/Top/Page.tsx
+++ b/src/components/templates/Top/Page.tsx
@@ -13,78 +13,82 @@ import theme from 'config/theme';
 import Form, { Props as FormProps } from 'components/organisms/Login/Form';
 import { StatusBar } from 'expo-status-bar';
 import Image from 'components/atoms/Image';
+import Loading from 'components/molecules/Overlay/Loading';
 
 export type Props = ConnectedType & FormProps & {};
 
 const Page: React.FC<Props> = (props) => {
   return (
-    <View style={styles.root}>
-      <StatusBar backgroundColor={theme().color.primary.main} style="dark" />
-      <SafeAreaView>
-        <View style={styles.inner}>
-          <ImageBackground
-            source={require('../../../img/common/frame.png')}
-            resizeMode="cover"
-            style={styles.image}
-          >
-            <View style={styles.title}>
-              <View>
-                <Image
-                  source={require('../../../img/common/logo.png')}
-                  width={384 / 2}
-                  height={84 / 2}
-                />
-              </View>
-
-              <View style={styles.skip}>
-                <TouchableOpacity onPress={props.onSkip}>
-                  <Text
-                    variants="small"
-                    style={styles.skipText}
-                    fontFamily="NotoSansJP-Bold"
-                    underline
-                  >
-                    スキップ
-                  </Text>
-                </TouchableOpacity>
-              </View>
-            </View>
-
-            <View style={styles.contents}>
-              <View style={styles.contentsTitle}>
-                <View style={styles.divider} />
+    <>
+      <View style={styles.root}>
+        <StatusBar backgroundColor={theme().color.primary.main} style="dark" />
+        <SafeAreaView>
+          <View style={styles.inner}>
+            <ImageBackground
+              source={require('../../../img/common/frame.png')}
+              resizeMode="cover"
+              style={styles.image}
+            >
+              <View style={styles.title}>
                 <View>
-                  <Text variants="small">新規登録</Text>
+                  <Image
+                    source={require('../../../img/common/logo.png')}
+                    width={384 / 2}
+                    height={84 / 2}
+                  />
                 </View>
-                <View style={styles.divider} />
-              </View>
-              <View style={styles.signed}>
-                <Form
-                  onAppleLogin={props.onAppleLogin}
-                  onGoogleLogin={props.onGoogleLogin}
-                />
-              </View>
-              <View style={styles.footer}>
-                <View style={styles.login}>
-                  <Text variants="small">すでにアカウントをお持ちの方</Text>
-                </View>
-                <View style={styles.loginText}>
-                  <TouchableOpacity onPress={props.onLogin}>
+
+                <View style={styles.skip}>
+                  <TouchableOpacity onPress={props.onSkip}>
                     <Text
-                      color="primary"
+                      variants="small"
+                      style={styles.skipText}
                       fontFamily="NotoSansJP-Bold"
                       underline
                     >
-                      ログイン
+                      スキップ
                     </Text>
                   </TouchableOpacity>
                 </View>
               </View>
-            </View>
-          </ImageBackground>
-        </View>
-      </SafeAreaView>
-    </View>
+
+              <View style={styles.contents}>
+                <View style={styles.contentsTitle}>
+                  <View style={styles.divider} />
+                  <View>
+                    <Text variants="small">新規登録</Text>
+                  </View>
+                  <View style={styles.divider} />
+                </View>
+                <View style={styles.signed}>
+                  <Form
+                    onAppleLogin={props.onAppleLogin}
+                    onGoogleLogin={props.onGoogleLogin}
+                  />
+                </View>
+                <View style={styles.footer}>
+                  <View style={styles.login}>
+                    <Text variants="small">すでにアカウントをお持ちの方</Text>
+                  </View>
+                  <View style={styles.loginText}>
+                    <TouchableOpacity onPress={props.onLogin}>
+                      <Text
+                        color="primary"
+                        fontFamily="NotoSansJP-Bold"
+                        underline
+                      >
+                        ログイン
+                      </Text>
+                    </TouchableOpacity>
+                  </View>
+                </View>
+              </View>
+            </ImageBackground>
+          </View>
+        </SafeAreaView>
+        {props.loading && <Loading text="ログイン中" />}
+      </View>
+    </>
   );
 };
 

--- a/src/components/templates/Top/__tests__/Page.test.tsx
+++ b/src/components/templates/Top/__tests__/Page.test.tsx
@@ -3,6 +3,7 @@ import { shallow, ShallowWrapper } from 'enzyme';
 import Page, { Props } from '../Page';
 
 const propsData = (): Props => ({
+  loading: false,
   onAppleLogin: jest.fn(),
   onGoogleLogin: jest.fn(),
   onSkip: jest.fn(),

--- a/src/components/templates/Top/__tests__/__snapshots__/Page.test.tsx.snap
+++ b/src/components/templates/Top/__tests__/__snapshots__/Page.test.tsx.snap
@@ -1,87 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`components/templates/Top/Page.tsx 正常にrenderすること 1`] = `
-<View
-  style={
-    Object {
-      "backgroundColor": "#E3C95D",
-      "height": "100%",
-    }
-  }
->
-  <ExpoStatusBar
-    backgroundColor="#E3C95D"
-    style="dark"
-  />
-  <ForwardRef>
-    <View
-      style={
-        Object {
-          "backgroundColor": "#FFFFFF",
-          "height": "100%",
-        }
+<Fragment>
+  <View
+    style={
+      Object {
+        "backgroundColor": "#E3C95D",
+        "height": "100%",
       }
-    >
-      <ImageBackground
-        resizeMode="cover"
-        source={null}
+    }
+  >
+    <ExpoStatusBar
+      backgroundColor="#E3C95D"
+      style="dark"
+    />
+    <ForwardRef>
+      <View
         style={
           Object {
-            "flex": 1,
-            "justifyContent": "center",
+            "backgroundColor": "#FFFFFF",
+            "height": "100%",
           }
         }
       >
-        <View
+        <ImageBackground
+          resizeMode="cover"
+          source={null}
           style={
             Object {
-              "alignItems": "center",
-              "height": "40%",
+              "flex": 1,
               "justifyContent": "center",
-              "width": "100%",
-            }
-          }
-        >
-          <View>
-            <Image
-              height={42}
-              source={null}
-              width={192}
-            />
-          </View>
-          <View
-            style={
-              Object {
-                "position": "absolute",
-                "right": 16,
-                "top": 16,
-              }
-            }
-          >
-            <TouchableOpacity
-              onPress={[MockFunction]}
-            >
-              <Text
-                fontFamily="NotoSansJP-Bold"
-                style={
-                  Object {
-                    "textDecorationLine": "underline",
-                  }
-                }
-                underline={true}
-                variants="small"
-              >
-                スキップ
-              </Text>
-            </TouchableOpacity>
-          </View>
-        </View>
-        <View
-          style={
-            Object {
-              "backgroundColor": "#FFFFFF",
-              "height": "60%",
-              "width": "100%",
             }
           }
         >
@@ -89,87 +37,25 @@ exports[`components/templates/Top/Page.tsx 正常にrenderすること 1`] = `
             style={
               Object {
                 "alignItems": "center",
-                "flexDirection": "row",
-                "height": 80,
+                "height": "40%",
                 "justifyContent": "center",
-              }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "borderColor": "#D8D7D6",
-                  "borderWidth": 0.5,
-                  "marginHorizontal": 32,
-                  "width": "30%",
-                }
-              }
-            />
-            <View>
-              <Text
-                fontFamily="RobotoCondensed-Bold"
-                variants="small"
-              >
-                新規登録
-              </Text>
-            </View>
-            <View
-              style={
-                Object {
-                  "borderColor": "#D8D7D6",
-                  "borderWidth": 0.5,
-                  "marginHorizontal": 32,
-                  "width": "30%",
-                }
-              }
-            />
-          </View>
-          <View
-            style={
-              Object {
-                "alignItems": "center",
-                "justifyContent": "center",
-                "paddingTop": 16,
                 "width": "100%",
               }
             }
           >
-            <Memo(Form)
-              onAppleLogin={[MockFunction]}
-              onGoogleLogin={[MockFunction]}
-            />
-          </View>
-          <View
-            style={
-              Object {
-                "alignItems": "flex-end",
-                "bottom": 16,
-                "flex": 1,
-                "flexDirection": "row",
-                "justifyContent": "space-between",
-                "paddingHorizontal": 16,
-                "paddingTop": 16,
-              }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "bottom": 4,
-                }
-              }
-            >
-              <Text
-                fontFamily="RobotoCondensed-Bold"
-                variants="small"
-              >
-                すでにアカウントをお持ちの方
-              </Text>
+            <View>
+              <Image
+                height={42}
+                source={null}
+                width={192}
+              />
             </View>
             <View
               style={
                 Object {
-                  "top": 0,
+                  "position": "absolute",
+                  "right": 16,
+                  "top": 16,
                 }
               }
             >
@@ -177,19 +63,135 @@ exports[`components/templates/Top/Page.tsx 正常にrenderすること 1`] = `
                 onPress={[MockFunction]}
               >
                 <Text
-                  color="primary"
                   fontFamily="NotoSansJP-Bold"
+                  style={
+                    Object {
+                      "textDecorationLine": "underline",
+                    }
+                  }
                   underline={true}
-                  variants="body"
+                  variants="small"
                 >
-                  ログイン
+                  スキップ
                 </Text>
               </TouchableOpacity>
             </View>
           </View>
-        </View>
-      </ImageBackground>
-    </View>
-  </ForwardRef>
-</View>
+          <View
+            style={
+              Object {
+                "backgroundColor": "#FFFFFF",
+                "height": "60%",
+                "width": "100%",
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "height": 80,
+                  "justifyContent": "center",
+                }
+              }
+            >
+              <View
+                style={
+                  Object {
+                    "borderColor": "#D8D7D6",
+                    "borderWidth": 0.5,
+                    "marginHorizontal": 32,
+                    "width": "30%",
+                  }
+                }
+              />
+              <View>
+                <Text
+                  fontFamily="RobotoCondensed-Bold"
+                  variants="small"
+                >
+                  新規登録
+                </Text>
+              </View>
+              <View
+                style={
+                  Object {
+                    "borderColor": "#D8D7D6",
+                    "borderWidth": 0.5,
+                    "marginHorizontal": 32,
+                    "width": "30%",
+                  }
+                }
+              />
+            </View>
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "justifyContent": "center",
+                  "paddingTop": 16,
+                  "width": "100%",
+                }
+              }
+            >
+              <Memo(Form)
+                onAppleLogin={[MockFunction]}
+                onGoogleLogin={[MockFunction]}
+              />
+            </View>
+            <View
+              style={
+                Object {
+                  "alignItems": "flex-end",
+                  "bottom": 16,
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "justifyContent": "space-between",
+                  "paddingHorizontal": 16,
+                  "paddingTop": 16,
+                }
+              }
+            >
+              <View
+                style={
+                  Object {
+                    "bottom": 4,
+                  }
+                }
+              >
+                <Text
+                  fontFamily="RobotoCondensed-Bold"
+                  variants="small"
+                >
+                  すでにアカウントをお持ちの方
+                </Text>
+              </View>
+              <View
+                style={
+                  Object {
+                    "top": 0,
+                  }
+                }
+              >
+                <TouchableOpacity
+                  onPress={[MockFunction]}
+                >
+                  <Text
+                    color="primary"
+                    fontFamily="NotoSansJP-Bold"
+                    underline={true}
+                    variants="body"
+                  >
+                    ログイン
+                  </Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+          </View>
+        </ImageBackground>
+      </View>
+    </ForwardRef>
+  </View>
+</Fragment>
 `;

--- a/src/components/templates/Top/stories.tsx
+++ b/src/components/templates/Top/stories.tsx
@@ -4,6 +4,7 @@ import { mockFn } from 'storyBookUtils/index';
 import Page, { Props } from './Page';
 
 const props = (): Props => ({
+  loading: false,
   onAppleLogin: mockFn('onAppleLogin'),
   onGoogleLogin: mockFn('onGoogleLogin'),
   onSkip: mockFn('onSkip'),

--- a/src/hooks/useFirebaseAuth.tsx
+++ b/src/hooks/useFirebaseAuth.tsx
@@ -183,6 +183,10 @@ const useFirebaseAuth = (login = false, errorCallback?: () => void) => {
       console.log('error:', response);
       Alert.alert('ログインに失敗しました');
       errorCallback?.();
+    } else if (response?.type === 'dismiss') {
+      errorCallback?.();
+    } else if (response?.type === 'cancel') {
+      errorCallback?.();
     }
   }, [response, prevResponseType, firebaseLogin, errorCallback, authUser.uid]);
 


### PR DESCRIPTION
## 関連 issue

- fixes #198 

## 対応内容

<img src=https://user-images.githubusercontent.com/19209314/171067714-e254f9f5-c4ed-439b-b189-0197a61c07c9.png  width=200>

 - ログイン後から画面が切り替わるまでにアプリが操作可能なので途中で操作すると、うまくログインできなくなるので、ログイン操作後にログイン中の表示を追加

## 開発用メモ
無し

