### PR TITLE
test: テストファイルの配置を修正 #319

### DIFF
--- a/components/elements/Animated/Blinking.test.tsx
+++ b/components/elements/Animated/Blinking.test.tsx
@@ -1,7 +1,7 @@
 import { testRenderer } from "@/lib/testUtil";
 import { screen } from "@testing-library/react-native";
 import React from "react";
-import Blinking, { type Props } from "../Blinking";
+import Blinking, { type Props } from "./Blinking";
 
 const propsData = (): Props => ({});
 

--- a/features/forceUpdate/Page.test.tsx
+++ b/features/forceUpdate/Page.test.tsx
@@ -1,7 +1,7 @@
 import { testRenderer } from "@/lib/testUtil";
 import { screen } from "@testing-library/react-native";
 import React from "react";
-import Page from "../Page";
+import Page from "./Page";
 
 describe("components/templates/ForceUpdate/Page.tsx", () => {
   it("正常にrenderすること", () => {

--- a/features/items/components/index.test.tsx
+++ b/features/items/components/index.test.tsx
@@ -12,7 +12,7 @@ import * as expoRouter from "expo-router";
 import { HttpResponse, graphql } from "msw";
 import React from "react";
 import * as Recoil from "recoil";
-import ItemDetail from "../";
+import ItemDetail from "./";
 
 describe("components/pages/ItemDetail/index.tsx", () => {
   beforeEach(() => {
@@ -54,7 +54,7 @@ describe("components/pages/ItemDetail/index.tsx", () => {
             },
           },
         });
-      }),
+      })
     );
 
     await waitFor(async () => {
@@ -90,7 +90,7 @@ describe("components/pages/ItemDetail/index.tsx", () => {
             },
           },
         });
-      }),
+      })
     );
 
     /*

--- a/features/search/components/index.test.tsx
+++ b/features/search/components/index.test.tsx
@@ -7,7 +7,7 @@ import {
 } from "@testing-library/react-native";
 import React from "react";
 import * as Recoil from "recoil";
-import IndexPage from "../";
+import IndexPage from "./";
 
 describe("components/pages/Search/index.tsx", () => {
   beforeEach(() => {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "lint:ci": "biome ci",
-    "prepare": "if [ -d .git ] && [ \"$NODE_ENV\" != \"production\" ]; then husky install; fi",
     "unused-exports": "node ./scripts/ts-unused-exports",
     "compare-images": "reg-suit sync-expected && reg-suit compare",
     "xcode": "open ios/memoir.xcworkspace"


### PR DESCRIPTION
## 変更内容

- テストファイルの配置を修正
  - ディレクトリを削除
  - テストファイルをテスト対象ファイルと同じ階層に移動

## テスト

- [x] 
> memoir@1.8.0 test /Users/iinoyouhei/go/src/github.com/wheatandcat/memoir
> jestを実行して、テスト実行数が元の状態から変わっていないことを確認
