### PR TITLE
iOSの曜日設定のドロップメニューの色が誤っている

### DIFF
--- a/components/layouts/Setting/Memoir/Input.tsx
+++ b/components/layouts/Setting/Memoir/Input.tsx
@@ -34,7 +34,7 @@ const Input: FC<Props> = (props) => {
       setOpenTime(false);
       props.onChangeTime(val);
     },
-    [props]
+    [props],
   );
 
   return (

--- a/components/layouts/Setting/Memoir/Input.tsx
+++ b/components/layouts/Setting/Memoir/Input.tsx
@@ -4,7 +4,7 @@ import theme from "@/config/theme";
 import dayjs from "@/lib/dayjs";
 import type { FC } from "react";
 import { memo, useCallback, useState } from "react";
-import { StyleSheet, TouchableOpacity } from "react-native";
+import { StyleSheet, TouchableOpacity, useColorScheme } from "react-native";
 import DateTimePickerModal from "react-native-modal-datetime-picker";
 import RNPickerSelect from "react-native-picker-select";
 
@@ -27,13 +27,14 @@ const dayOfWeekItems = [
 
 const Input: FC<Props> = (props) => {
   const [openTime, setOpenTime] = useState(false);
+  const colorScheme = useColorScheme();
 
   const onChangeTime = useCallback(
     (val: Date) => {
       setOpenTime(false);
       props.onChangeTime(val);
     },
-    [props],
+    [props]
   );
 
   return (
@@ -47,17 +48,19 @@ const Input: FC<Props> = (props) => {
             value={props.dayOfWeek}
             onValueChange={props.onChangeDayOfWeek}
             items={dayOfWeekItems}
+            darkTheme={colorScheme === "dark"}
             style={{
               placeholder: {
                 width: 40,
                 height: 50,
                 color: theme().color.secondary.main,
               },
-              inputIOSContainer: { pointerEvents: "none" },
+              inputIOSContainer: {
+                pointerEvents: "none",
+              },
               inputIOS: {
                 fontSize: theme().fontSizes.xl,
                 fontWeight: theme().fontWeights.bold,
-                color: theme().color.secondary.main,
                 width: 40,
                 height: 50,
                 paddingTop: theme().space(3),
@@ -65,7 +68,6 @@ const Input: FC<Props> = (props) => {
               inputAndroid: {
                 fontSize: theme().fontSizes.xl,
                 fontWeight: theme().fontWeights.bold,
-                color: theme().color.secondary.main,
                 width: 50,
                 height: 65,
                 marginTop: theme().space(2),


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 関連 issue

- fixes #379 

## 対応内容
<img width="200" height="2556" alt="Simulator Screenshot - iPhone 15 - 2025-08-05 at 22 27 18" src="https://github.com/user-attachments/assets/e6f8739f-7705-41ce-8f68-e0a023801e78" />
 - dark modeに対応してなかったので修正




## 開発用メモ
無し

