### PR TITLE
アカウント削除後の画面が表示されていない

### DIFF
--- a/app/sign-in.tsx
+++ b/app/sign-in.tsx
@@ -1,5 +1,7 @@
+import SeeYouAgain from "@/components/layouts/SeeYouAgain/SeeYouAgain";
 import Page from "@/features/top/components/Connected";
 import useUser from "@/hooks/useUser";
+import { useScreenStore } from "@/store/screenStore";
 import { NotoSansJP_700Bold } from "@expo-google-fonts/noto-sans-jp";
 import { RobotoCondensed_700Bold } from "@expo-google-fonts/roboto-condensed";
 import * as Font from "expo-font";
@@ -11,6 +13,7 @@ SplashScreen.preventAutoHideAsync();
 export default function SignIn() {
   const { user, onSaveWhenNotLogin } = useUser();
   const [create, setCreate] = useState(false);
+  const screenState = useScreenStore((state) => state.screen);
 
   const onSkip = useCallback(() => {
     setCreate(true);
@@ -24,6 +27,10 @@ export default function SignIn() {
 
   if (!fontsLoaded) {
     return null;
+  }
+
+  if (screenState.seeYouAgain) {
+    return <SeeYouAgain />;
   }
 
   return (

--- a/components/layouts/SeeYouAgain/SeeYouAgain.tsx
+++ b/components/layouts/SeeYouAgain/SeeYouAgain.tsx
@@ -4,6 +4,7 @@ import Text from "@/components/elements/Text";
 import View from "@/components/elements/View";
 import theme from "@/config/theme";
 import { useScreenStore } from "@/store/screenStore";
+import { StatusBar } from "expo-status-bar";
 import type { FC } from "react";
 import { memo } from "react";
 import { ScrollView, StyleSheet } from "react-native";
@@ -13,35 +14,38 @@ const SeeYouAgain: FC = () => {
   const setScreenState = useScreenStore((state) => state.setSeeYouAgain);
 
   return (
-    <SafeAreaView>
-      <View style={styles.root}>
-        <ScrollView>
-          <View style={styles.inner}>
-            <View pt={4} pb={5}>
-              <Image
-                source={require("@/assets/img/icon/trust.png")}
-                width={100}
-                height={100}
-                contentFit="contain"
-              />
+    <View style={styles.root}>
+      <StatusBar style="dark" />
+      <SafeAreaView>
+        <View>
+          <ScrollView>
+            <View style={styles.inner}>
+              <View pt={4} pb={5}>
+                <Image
+                  source={require("@/assets/img/icon/trust.png")}
+                  width={100}
+                  height={100}
+                  contentFit="contain"
+                />
+              </View>
+              <Text size="base">
+                アカウント削除が完了しました。{"\n\n"}
+                ご利用ありがとうございました。{"\n\n"}また、会いましょう。
+              </Text>
+              <View py={5}>
+                <Button
+                  title="TOPに戻る"
+                  onPress={() => {
+                    setScreenState(false);
+                  }}
+                  width={200}
+                />
+              </View>
             </View>
-            <Text size="base">
-              アカウント削除が完了しました。{"\n\n"}
-              ご利用ありがとうございました。{"\n\n"}また、会いましょう。
-            </Text>
-            <View py={5}>
-              <Button
-                title="TOPに戻る"
-                onPress={() => {
-                  setScreenState(false);
-                }}
-                width={200}
-              />
-            </View>
-          </View>
-        </ScrollView>
-      </View>
-    </SafeAreaView>
+          </ScrollView>
+        </View>
+      </SafeAreaView>
+    </View>
   );
 };
 

--- a/features/setting/dataManagement/components/Connected.tsx
+++ b/features/setting/dataManagement/components/Connected.tsx
@@ -32,7 +32,7 @@ const Connected: React.FC = () => {
         await onLogout();
         setScreenState(true);
       },
-    },
+    }
   );
 
   const onDelete = useCallback(() => {

--- a/features/setting/dataManagement/components/Connected.tsx
+++ b/features/setting/dataManagement/components/Connected.tsx
@@ -32,7 +32,7 @@ const Connected: React.FC = () => {
         await onLogout();
         setScreenState(true);
       },
-    }
+    },
   );
 
   const onDelete = useCallback(() => {


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 関連 issue

- fixes #387 

## 対応内容

 - アカウント削除後に以下の画面が表示されるように修正
  - <img width="200" height="2796" alt="Simulator Screenshot - iPhone 16 Plus - 2025-08-11 at 14 18 07" src="https://github.com/user-attachments/assets/fe4b4487-8315-4180-99bb-61ffca9f22c4" />


## 開発用メモ
無し

