### PR TITLE
Androidでinputのautofocusがきいていない

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -3,7 +3,7 @@ import dayjs from "dayjs";
 import "dayjs/locale/ja";
 import "dotenv/config";
 
-const version: string = "1.9.1";
+const version: string = "1.9.2";
 const unix = dayjs().unix().toString();
 
 export default ({ config }: ConfigContext): ExpoConfig => ({

--- a/components/elements/TextInput/TextInput.tsx
+++ b/components/elements/TextInput/TextInput.tsx
@@ -1,6 +1,7 @@
 import View from "@/components/elements/View";
 import theme from "@/config/theme";
 import type { FC } from "react";
+import { useEffect, useRef } from "react";
 import {
   TextInput as RNTextInput,
   StyleSheet,
@@ -12,17 +13,28 @@ type Props = TextInputProps;
 
 const TextInput: FC<Props> = (props) => {
   const style: TextStyle[] = [styles.text];
+  const textInputRef = useRef<RNTextInput>(null);
+
+  const { autoFocus, ...rest } = props;
+
   if (props.style) {
     style.push(props.style as TextStyle);
   }
 
+  useEffect(() => {
+    if (autoFocus) {
+      setTimeout(() => textInputRef.current?.focus(), 100);
+    }
+  }, [autoFocus]);
+
   return (
     <View>
       <RNTextInput
-        {...props}
+        {...rest}
         placeholderTextColor={theme().color.base.main}
         style={style}
         autoCapitalize="none"
+        ref={textInputRef}
       />
       <View style={styles.underLine} />
     </View>

--- a/components/layouts/AddItemModal/AddItemModal.tsx
+++ b/components/layouts/AddItemModal/AddItemModal.tsx
@@ -47,7 +47,7 @@ const AddItemModal: FC<Props> = ({
   ...props
 }) => {
   const [state, setState] = useState<State>(
-    initialState(props.date, props.item)
+    initialState(props.date, props.item),
   );
   const prevIsVisible = usePrevious(props.isVisible);
   const [openDate, setOpenDate] = useState(false);

--- a/components/layouts/AddItemModal/AddItemModal.tsx
+++ b/components/layouts/AddItemModal/AddItemModal.tsx
@@ -47,7 +47,7 @@ const AddItemModal: FC<Props> = ({
   ...props
 }) => {
   const [state, setState] = useState<State>(
-    initialState(props.date, props.item),
+    initialState(props.date, props.item)
   );
   const prevIsVisible = usePrevious(props.isVisible);
   const [openDate, setOpenDate] = useState(false);
@@ -150,8 +150,8 @@ const AddItemModal: FC<Props> = ({
         <TextInput
           placeholder="今日何やった？"
           onChangeText={onChangeTitle}
-          autoFocus
           returnKeyType="done"
+          autoFocus
           defaultValue={state.title}
           style={state.title ? styles.input : styles.placeholder}
         />

--- a/features/setting/contact/components/Page.tsx
+++ b/features/setting/contact/components/Page.tsx
@@ -5,14 +5,25 @@ import Modal from "@/components/layouts/Modal";
 import theme from "@/config/theme";
 import * as Clipboard from "expo-clipboard";
 import type React from "react";
-import { memo, useCallback } from "react";
-import { StyleSheet, TouchableOpacity } from "react-native";
-import { TextInput as RNTextInput } from "react-native";
+import { memo, useCallback, useEffect, useRef } from "react";
+import {
+  TextInput as RNTextInput,
+  StyleSheet,
+  TouchableOpacity,
+} from "react-native";
 import type { ConnectedType } from "./type";
 
 export type Props = ConnectedType & {};
 
 const Page: React.FC<Props> = (props) => {
+  const textInputRef = useRef<RNTextInput>(null);
+
+  useEffect(() => {
+    const id = setTimeout(() => textInputRef.current?.focus(), 100);
+
+    return () => clearTimeout(id);
+  }, []);
+
   const onCopyUserID = useCallback(() => {
     Clipboard.setStringAsync(props.userID);
   }, [props.userID]);
@@ -44,11 +55,11 @@ const Page: React.FC<Props> = (props) => {
         </View>
         <RNTextInput
           multiline
+          ref={textInputRef}
           style={styles.inputText}
           autoCapitalize="none"
           onChangeText={props.onChangeText}
           maxLength={300}
-          autoFocus
         />
       </View>
       <Modal


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 関連 issue

- fixes #398 

## 対応内容
 - [TextInput autofocus is not opening keyboard on Android](https://github.com/callstack/react-native-paper/issues/4456)
 - Androidでautofocusを設定してもキーボードが表示されない不具合を修正

## 開発用メモ
無し

